### PR TITLE
Hide stack traces

### DIFF
--- a/bobrun/compose.go
+++ b/bobrun/compose.go
@@ -3,9 +3,11 @@ package bobrun
 import (
 	"context"
 	"fmt"
+
 	"github.com/Benchkram/bob/pkg/composectl"
 	"github.com/Benchkram/bob/pkg/composeutil"
 	"github.com/Benchkram/bob/pkg/ctl"
+	"github.com/Benchkram/bob/pkg/usererror"
 	"github.com/Benchkram/errz"
 )
 
@@ -32,7 +34,7 @@ func (r *Run) composeCommand(ctx context.Context) (_ ctl.Command, err error) {
 		portConflicts = conflicts.String()
 
 		// TODO: disable once we also resolve binaries' ports
-		errz.Fatal(fmt.Errorf(fmt.Sprint("conflicting ports detected:\n", conflicts)))
+		errz.Fatal(usererror.Wrap(fmt.Errorf(fmt.Sprint("conflicting ports detected:\n", conflicts))))
 
 		resolved, err := composeutil.ResolvePortConflicts(conflicts)
 		errz.Fatal(err)

--- a/cli/cmd_run.go
+++ b/cli/cmd_run.go
@@ -57,6 +57,7 @@ func run(taskname string, noCache bool) {
 
 		return
 	}
+	defer t.Restore()
 
 	commander, err := b.Run(ctx, taskname)
 	if err != nil {
@@ -65,6 +66,7 @@ func run(taskname string, noCache bool) {
 		default:
 			if errors.As(err, &usererror.Err) {
 				boblog.Log.UserError(err)
+				return
 			} else {
 				errz.Fatal(err)
 			}
@@ -80,8 +82,6 @@ func run(taskname string, noCache bool) {
 	if commander != nil {
 		<-commander.Done()
 	}
-
-	t.Restore()
 }
 
 func getRuns() ([]string, error) {

--- a/cli/cmd_run.go
+++ b/cli/cmd_run.go
@@ -40,6 +40,9 @@ var runCmd = &cobra.Command{
 }
 
 func run(taskname string, noCache bool) {
+	var err error
+	defer errz.Recover(&err)
+
 	b, err := bob.Bob(
 		bob.WithCachingEnabled(!noCache),
 	)

--- a/cli/cmd_workspace.go
+++ b/cli/cmd_workspace.go
@@ -1,9 +1,12 @@
 package cli
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 
 	"github.com/Benchkram/bob/bob"
+	"github.com/Benchkram/bob/pkg/boblog"
 	"github.com/Benchkram/errz"
 )
 
@@ -17,9 +20,15 @@ var cmdWorkspace = &cobra.Command{
 }
 
 func runInit() {
-	bob, err := bob.Bob()
+	b, err := bob.Bob()
 	errz.Fatal(err)
 
-	err = bob.Init()
-	errz.Fatal(err)
+	err = b.Init()
+	if err != nil {
+		if errors.Is(err, bob.ErrWorkspaceAlreadyInitialised) {
+			boblog.Log.UserError(err)
+		} else {
+			errz.Fatal(err)
+		}
+	}
 }

--- a/pkg/execctl/cmd.go
+++ b/pkg/execctl/cmd.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/Benchkram/bob/pkg/ctl"
+	"github.com/Benchkram/bob/pkg/usererror"
 )
 
 var (
@@ -122,7 +123,7 @@ func (c *Cmd) Start() error {
 	// start the command
 	err := c.cmd.Start()
 	if err != nil {
-		return err
+		return usererror.Wrapm(err, "Command execution failed")
 	}
 
 	go func() {

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -2,11 +2,12 @@ package tui
 
 import (
 	"fmt"
+	"os"
+	"time"
+
 	"github.com/Benchkram/bob/pkg/ctl"
 	"github.com/Benchkram/errz"
 	tea "github.com/charmbracelet/bubbletea"
-	"os"
-	"time"
 )
 
 type TUI struct {
@@ -30,8 +31,7 @@ func New() (*TUI, error) {
 		return nil, err
 	}
 
-	os.Stdout = wout
-	os.Stderr = wout
+	// Redirect of stderr and stdout will happen in (t *TUI) Start(cmder ctl.Commander)
 
 	buf, err := multiScanner(0, evts, rout)
 	if err != nil {
@@ -50,6 +50,12 @@ func New() (*TUI, error) {
 
 func (t *TUI) Start(cmder ctl.Commander) {
 	t.started = true
+
+	// Redirect stdout and stderr
+	// Do this as late as possible
+	// Any logging to stdout and stderr between redirecting and actually starting logging from new out/err
+	os.Stdout = t.output
+	os.Stderr = t.output
 
 	programEvts := make(chan interface{}, 1)
 

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -31,7 +31,9 @@ func New() (*TUI, error) {
 		return nil, err
 	}
 
-	// Redirect of stderr and stdout will happen in (t *TUI) Start(cmder ctl.Commander)
+	// Redirect of stderr and stdout to cache all logging until tui is either started or restored
+	os.Stdout = wout
+	os.Stderr = wout
 
 	buf, err := multiScanner(0, evts, rout)
 	if err != nil {
@@ -50,12 +52,6 @@ func New() (*TUI, error) {
 
 func (t *TUI) Start(cmder ctl.Commander) {
 	t.started = true
-
-	// Redirect stdout and stderr
-	// Do this as late as possible
-	// Any logging to stdout and stderr between redirecting and actually starting logging from new out/err
-	os.Stdout = t.output
-	os.Stderr = t.output
 
 	programEvts := make(chan interface{}, 1)
 


### PR DESCRIPTION
Fix for https://github.com/benchkram/bob-private/issues/162
Also resolves a problem with `tui` "swallowing" logs before calling `tui.Start()`