### PR TITLE
Bob clone issues

### DIFF
--- a/bob/add.go
+++ b/bob/add.go
@@ -9,19 +9,17 @@ import (
 )
 
 // Add, adds the rawurl as a repositoroy to bob workspace. Set all url if
-// explicit url set to false.
+// `plain` variable set to false.
 //
-// if explicit protocol set to true,
+// if plain set to true,
 //
 // set the sshurl & localurl to "" if url is a valid http,
-//
-// set the httpurl and sshurl to "" if url is a filepath
-//
-// else it presumes url type as ssh and set http url to ""
-func (b *B) Add(rawurl string, explcitprotcl bool) (err error) {
+// set the httpurl and sshurl to "" if url is a filepath,
+// else it presumes url type as ssh and set http url to "".
+func (b *B) Add(rawurl string, plain bool) (err error) {
 	defer errz.Recover(&err)
 
-	// check if url ends with `.git`
+	// check if remote url ends with `.git`
 	isValid := checkIfURLEndsWithGit(rawurl)
 	if !isValid {
 		return usererror.Wrapm(ErrInvalidURL, "GIT url Add failed")
@@ -45,13 +43,13 @@ func (b *B) Add(rawurl string, explcitprotcl bool) (err error) {
 	sshstr := repo.SSH.String()
 	localstr := repo.Local
 
-	if explcitprotcl && checkIfHttp(rawurl) {
+	if plain && checkIfHttp(rawurl) {
 		sshstr = ""
 		localstr = ""
-	} else if explcitprotcl && checkIfFile(rawurl) {
+	} else if plain && checkIfFile(rawurl) {
 		httpsstr = ""
 		sshstr = ""
-	} else if explcitprotcl {
+	} else if plain {
 		httpsstr = ""
 	}
 

--- a/bob/add.go
+++ b/bob/add.go
@@ -1,10 +1,12 @@
 package bob
 
 import (
+	"strings"
+
 	"github.com/Benchkram/errz"
 )
 
-func (b *B) Add(rawurl string, httpsonly bool, sshonly bool) (err error) {
+func (b *B) Add(rawurl string, explcitprotcl bool) (err error) {
 	defer errz.Recover(&err)
 
 	// Check if it is a valid git repo
@@ -22,13 +24,15 @@ func (b *B) Add(rawurl string, httpsonly bool, sshonly bool) (err error) {
 	}
 
 	httpsstr := repo.HTTPS.String()
-	if sshonly {
-		httpsstr = ""
-	}
-
 	sshstr := repo.SSH.String()
-	if httpsonly {
+
+	// if explicit protocol set to true,
+	// set the sshurl to "" if url starts with http,
+	// else http url set to ""
+	if explcitprotcl && checkIfHttp(rawurl) {
 		sshstr = ""
+	} else if explcitprotcl {
+		httpsstr = ""
 	}
 
 	b.Repositories = append(b.Repositories,
@@ -44,4 +48,11 @@ func (b *B) Add(rawurl string, httpsonly bool, sshonly bool) (err error) {
 	errz.Fatal(err)
 
 	return b.write()
+}
+
+// checkIfHttp returns true if url is http,
+//
+// It is easier to detect if the url is http/s protocol.
+func checkIfHttp(rawurl string) bool {
+	return strings.HasPrefix(rawurl, "http")
 }

--- a/bob/add.go
+++ b/bob/add.go
@@ -91,7 +91,7 @@ func getScheme(rawurl string) (string, error) {
 	}
 
 	// giturl parse detects url like `git@github.com` without `:` as files
-	// which is a wrong URL but logically a `ssh`
+	// which is usually done using `ssh`.
 	if strings.Contains(rawurl, "git@") {
 		return "ssh", nil
 	}

--- a/bob/add.go
+++ b/bob/add.go
@@ -11,9 +11,10 @@ import (
 
 // Add, adds a repositoroy to a workspace.
 //
-// Automatically tries to guess the contrary url (git/https)
+// Automatically tries to guess the contrary url (git@/https://)
 // from the given rawurl. This behavior can be deactivated
-// if plain is set to true.
+// if plain is set to true. In case of a local path (file://)
+// plain has no effect.
 func (b *B) Add(rawurl string, plain bool) (err error) {
 	defer errz.Recover(&err)
 

--- a/bob/add.go
+++ b/bob/add.go
@@ -4,7 +4,7 @@ import (
 	"github.com/Benchkram/errz"
 )
 
-func (b *B) Add(rawurl string) (err error) {
+func (b *B) Add(rawurl string, httpsonly bool, sshonly bool) (err error) {
 	defer errz.Recover(&err)
 
 	// Check if it is a valid git repo
@@ -21,11 +21,21 @@ func (b *B) Add(rawurl string) (err error) {
 		}
 	}
 
+	httpsstr := repo.HTTPS.String()
+	if sshonly {
+		httpsstr = ""
+	}
+
+	sshstr := repo.SSH.String()
+	if httpsonly {
+		sshstr = ""
+	}
+
 	b.Repositories = append(b.Repositories,
 		Repo{
 			Name:     name,
-			HTTPSUrl: repo.HTTPS.String(),
-			SSHUrl:   repo.SSH.String(),
+			HTTPSUrl: httpsstr,
+			SSHUrl:   sshstr,
 			LocalUrl: repo.Local,
 		},
 	)

--- a/bob/add.go
+++ b/bob/add.go
@@ -19,12 +19,6 @@ import (
 func (b *B) Add(rawurl string, plain bool) (err error) {
 	defer errz.Recover(&err)
 
-	// check if remote url ends with `.git`
-	isValid := checkIfURLEndsWithGit(rawurl)
-	if !isValid {
-		return usererror.Wrapm(ErrInvalidURL, "GIT url Add failed")
-	}
-
 	// Check if it is a valid git repo
 	repo, err := Parse(rawurl)
 	errz.Fatal(err)
@@ -80,33 +74,6 @@ func (b *B) Add(rawurl string, plain bool) (err error) {
 	return b.write()
 }
 
-// checkIfURLEndsWithGit checks if the provided url string
-// has `.git` or `.git/` suffix on its end.
-//
-// Ignores local urls.
-func checkIfURLEndsWithGit(rawurl string) bool {
-	if checkIfFile(rawurl) {
-		return true
-	}
-
-	trimmed := strings.TrimSuffix(rawurl, "/")
-	if strings.HasSuffix(trimmed, ".git") {
-		return true
-	} else {
-		return false
-	}
-}
-
-// checkIfFile returns true if url is filepath
-func checkIfFile(rawurl string) bool {
-	scheme, err := getScheme(rawurl)
-	if err != nil {
-		return false
-	}
-
-	return scheme == "file"
-}
-
 // getScheme check if the url is valid,
 // if valid returns the url scheme
 func getScheme(rawurl string) (string, error) {
@@ -115,6 +82,8 @@ func getScheme(rawurl string) (string, error) {
 		return "", err
 	}
 
+	// giturl parse detects url like `git@github.com` without `:` as files
+	// which is a wrong URL but logically a `ssh`
 	if strings.Contains(rawurl, "git@") {
 		return "ssh", nil
 	}

--- a/bob/add.go
+++ b/bob/add.go
@@ -1,11 +1,21 @@
 package bob
 
 import (
-	"strings"
+	"net/url"
 
 	"github.com/Benchkram/errz"
 )
 
+// Add, adds the rawurl as a repositoroy to bob workspace. Set all url if
+// explicit url set to false.
+//
+// if explicit protocol set to true,
+//
+// set the sshurl & localurl to "" if url is a valid http,
+//
+// set the httpurl and sshurl to "" if url is a filepath
+//
+// else it presumes url type as ssh and set http url to ""
 func (b *B) Add(rawurl string, explcitprotcl bool) (err error) {
 	defer errz.Recover(&err)
 
@@ -25,11 +35,13 @@ func (b *B) Add(rawurl string, explcitprotcl bool) (err error) {
 
 	httpsstr := repo.HTTPS.String()
 	sshstr := repo.SSH.String()
+	localstr := repo.Local
 
-	// if explicit protocol set to true,
-	// set the sshurl to "" if url starts with http,
-	// else http url set to ""
 	if explcitprotcl && checkIfHttp(rawurl) {
+		sshstr = ""
+		localstr = ""
+	} else if explcitprotcl && checkIfFile(rawurl) {
+		httpsstr = ""
 		sshstr = ""
 	} else if explcitprotcl {
 		httpsstr = ""
@@ -40,7 +52,7 @@ func (b *B) Add(rawurl string, explcitprotcl bool) (err error) {
 			Name:     name,
 			HTTPSUrl: httpsstr,
 			SSHUrl:   sshstr,
-			LocalUrl: repo.Local,
+			LocalUrl: localstr,
 		},
 	)
 
@@ -51,8 +63,41 @@ func (b *B) Add(rawurl string, explcitprotcl bool) (err error) {
 }
 
 // checkIfHttp returns true if url is http,
-//
-// It is easier to detect if the url is http/s protocol.
 func checkIfHttp(rawurl string) bool {
-	return strings.HasPrefix(rawurl, "http")
+	err := isValidUrl(rawurl)
+	if err != nil {
+		return false
+	}
+
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		return false
+	}
+
+	return u.Scheme == "http" || u.Scheme == "https"
+}
+
+// checkIfFile returns true if url is filepath
+func checkIfFile(rawurl string) bool {
+	err := isValidUrl(rawurl)
+	if err != nil {
+		return false
+	}
+
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		return false
+	}
+
+	return u.Scheme == "file"
+}
+
+// isValidUrl tests a string to determine if it is a well-structured url or not.
+func isValidUrl(toTest string) error {
+	_, err := url.ParseRequestURI(toTest)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/bob/bob.go
+++ b/bob/bob.go
@@ -20,9 +20,6 @@ import (
 var Version = "0.0.0"
 
 type B struct {
-	// DefaultCloneSchema used for cloning repos, `ssh` | `https`
-	DefaultCloneSchema CloneSchema
-
 	// Repositories to track.
 	Repositories []Repo `yaml:"repositories"`
 
@@ -53,9 +50,8 @@ func newBob(opts ...Option) *B {
 	}
 
 	b := &B{
-		DefaultCloneSchema: SSH,
-		dir:                wd,
-		enableCaching:      true,
+		dir:           wd,
+		enableCaching: true,
 	}
 
 	for _, opt := range opts {

--- a/bob/clone.go
+++ b/bob/clone.go
@@ -86,10 +86,7 @@ func (b *B) CloneRepo(repoURL string) (_ string, err error) {
 	repo, err := Parse(repoURL)
 	errz.Fatal(err)
 
-	// TODO: let repoName be handled by Parse().
-	repoName := RepoName(repo.HTTPS.URL)
-
-	absRepoPath, err := filepath.Abs(repoName)
+	absRepoPath, err := filepath.Abs(repo.Name())
 	errz.Fatal(err)
 
 	wd, err := os.Getwd()
@@ -115,7 +112,7 @@ func (b *B) CloneRepo(repoURL string) (_ string, err error) {
 		return "", err
 	}
 
-	return repoName, nil
+	return repo.Name(), nil
 }
 
 // makeURLPriorityList returns list of cloneURLItem from forwarded repo,

--- a/bob/clone.go
+++ b/bob/clone.go
@@ -140,7 +140,7 @@ func makeURLPriorityList(repo Repo) ([]cloneURLItem, error) {
 	}
 
 	if !ignoressh {
-		repoFromSSH, err := Parse(repo.HTTPSUrl)
+		repoFromSSH, err := Parse(repo.SSHUrl)
 		if err != nil {
 			return nil, err
 		}

--- a/bob/clone.go
+++ b/bob/clone.go
@@ -3,7 +3,6 @@ package bob
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -106,9 +105,6 @@ func (b *B) CloneRepo(repoURL string) (_ string, err error) {
 	errz.Fatal(err)
 
 	if err := bob.Clone(); err != nil {
-		if err := os.RemoveAll(absRepoPath); err != nil {
-			log.Printf("failed to remove cloned repo: %v\n", err)
-		}
 		return "", err
 	}
 

--- a/bob/clone.go
+++ b/bob/clone.go
@@ -126,20 +126,10 @@ func (b *B) CloneRepo(repoURL string) (_ string, err error) {
 // It als Checks if it is a valid git repo,
 // as someone might changed it on disk.
 func makeURLPriorityList(repo Repo) ([]cloneURLItem, error) {
-	var ignorehttp bool = false
-	var ignoressh bool = false
 
 	var urls []cloneURLItem
 
-	if repo.SSHUrl == "" {
-		ignoressh = true
-	}
-
-	if repo.HTTPSUrl == "" {
-		ignorehttp = true
-	}
-
-	if !ignoressh {
+	if repo.SSHUrl != "" {
 		repoFromSSH, err := Parse(repo.SSHUrl)
 		if err != nil {
 			return nil, err
@@ -150,7 +140,7 @@ func makeURLPriorityList(repo Repo) ([]cloneURLItem, error) {
 		})
 	}
 
-	if !ignorehttp {
+	if repo.HTTPSUrl != "" {
 		repoFromHTTPS, err := Parse(repo.HTTPSUrl)
 		if err != nil {
 			return nil, err

--- a/bob/clone.go
+++ b/bob/clone.go
@@ -30,8 +30,8 @@ type cloneURLItem struct {
 //
 // failFast will not prompt the user in case of an error.
 //
-// TODO: it might still happens that https prompts for user input
-// in case of a missing password.
+// TODO: it still happens that git prompts for user input
+// in case of a missing password on https.
 func (b *B) Clone(failFast bool) (err error) {
 	defer errz.Recover(&err)
 

--- a/bob/clone.go
+++ b/bob/clone.go
@@ -182,7 +182,7 @@ func FprintCloneOutput(reponame string, output []byte, success bool) *bytes.Buff
 func FprintRepoTitle(reponame string, maxlen int, success bool) *bytes.Buffer {
 	buf := bytes.NewBuffer(nil)
 	spacing := "%-" + fmt.Sprint(maxlen) + "s"
-	repopath := fmt.Sprintf(spacing, formatRepoNameForOutput(reponame))
+	repopath := fmt.Sprintf(spacing, sanitizeReponame(reponame))
 	title := fmt.Sprint(repopath, "\t", aurora.Green("success"))
 	if !success {
 		title = fmt.Sprint(repopath, "\t", aurora.Red("error"))
@@ -193,10 +193,10 @@ func FprintRepoTitle(reponame string, maxlen int, success bool) *bytes.Buffer {
 	return buf
 }
 
-// formatRepoNameForOutput returns formatted reponame for output.
+// sanitizeReponame returns sanitized reponame.
 //
 // Example: "." => "/", "second-level" => "second-level/"
-func formatRepoNameForOutput(reponame string) string {
+func sanitizeReponame(reponame string) string {
 	repopath := reponame
 	if reponame == "." {
 		repopath = "/"

--- a/bob/error.go
+++ b/bob/error.go
@@ -3,13 +3,15 @@ package bob
 import "fmt"
 
 var (
-	ErrConfigFileDoesNotExist      = fmt.Errorf("Config file does not exist")
-	ErrRepoAlreadyAdded            = fmt.Errorf("Repo already added")
-	ErrTaskDoesNotExist            = fmt.Errorf("Task does not exist")
-	ErrRunDoesNotExist             = fmt.Errorf("Run does not exist")
-	ErrWorkspaceAlreadyInitialised = fmt.Errorf("Bob Workspace Already Initialized")
-	ErrTargetValidationFailed      = fmt.Errorf("Target validation failed")
-	ErrCouldNotFindTopLevelBobfile = fmt.Errorf("Could not find top-level Bobfile")
+	ErrConfigFileDoesNotExist      = fmt.Errorf("config file does not exist")
+	ErrRepoAlreadyAdded            = fmt.Errorf("repo already added")
+	ErrTaskDoesNotExist            = fmt.Errorf("task does not exist")
+	ErrRunDoesNotExist             = fmt.Errorf("run does not exist")
+	ErrWorkspaceAlreadyInitialised = fmt.Errorf("bob Workspace Already Initialized")
+	ErrTargetValidationFailed      = fmt.Errorf("target validation failed")
+	ErrCouldNotFindTopLevelBobfile = fmt.Errorf("could not find top-level Bobfile")
 	ErrInvalidVersion              = fmt.Errorf("invalid version")
-	ErrInsecuredHTTPURL            = fmt.Errorf("Insecured HTTP url not supported")
+	ErrInsecuredHTTPURL            = fmt.Errorf("insecured http url not supported")
+	ErrInvalidScheme               = fmt.Errorf("invalid scheme")
+	ErrInvalidGitUrl               = fmt.Errorf("invalid git url")
 )

--- a/bob/error.go
+++ b/bob/error.go
@@ -11,6 +11,5 @@ var (
 	ErrTargetValidationFailed      = fmt.Errorf("Target validation failed")
 	ErrCouldNotFindTopLevelBobfile = fmt.Errorf("Could not find top-level Bobfile")
 	ErrInvalidVersion              = fmt.Errorf("invalid version")
-	ErrInvalidURL                  = fmt.Errorf("Provided URL is not a Valid URL.")
 	ErrInsecuredHTTPURL            = fmt.Errorf("Insecured HTTP url not supported")
 )

--- a/bob/error.go
+++ b/bob/error.go
@@ -11,4 +11,5 @@ var (
 	ErrTargetValidationFailed      = fmt.Errorf("Target validation failed")
 	ErrCouldNotFindTopLevelBobfile = fmt.Errorf("Could not find top-level Bobfile")
 	ErrInvalidVersion              = fmt.Errorf("invalid version")
+	ErrInvalidURL                  = fmt.Errorf("Provided URL is not a Valid URL.")
 )

--- a/bob/error.go
+++ b/bob/error.go
@@ -14,4 +14,5 @@ var (
 	ErrInsecuredHTTPURL            = fmt.Errorf("insecured http url not supported")
 	ErrInvalidScheme               = fmt.Errorf("invalid scheme")
 	ErrInvalidGitUrl               = fmt.Errorf("invalid git url")
+	ErrInvalidRepositoryName       = fmt.Errorf("invalid repository name")
 )

--- a/bob/error.go
+++ b/bob/error.go
@@ -12,4 +12,5 @@ var (
 	ErrCouldNotFindTopLevelBobfile = fmt.Errorf("Could not find top-level Bobfile")
 	ErrInvalidVersion              = fmt.Errorf("invalid version")
 	ErrInvalidURL                  = fmt.Errorf("Provided URL is not a Valid URL.")
+	ErrInsecuredHTTPURL            = fmt.Errorf("Insecured HTTP url not supported")
 )

--- a/cli/cmd_clone.go
+++ b/cli/cmd_clone.go
@@ -1,9 +1,12 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
+	"os"
 
 	"github.com/Benchkram/bob/bob"
+	"github.com/Benchkram/bob/pkg/usererror"
 	"github.com/Benchkram/errz"
 
 	"github.com/logrusorgru/aurora"
@@ -15,23 +18,25 @@ var CmdClone = &cobra.Command{
 	Short: "Clone a bob workspace and child repositorys",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
+		failFast, err := cmd.Flags().GetBool("fail-fast")
+		errz.Fatal(err)
+
 		var url string
 		if len(args) > 0 {
 			url = args[0]
 		}
-
-		runClone(url)
+		runClone(url, failFast)
 	},
 }
 
-func runClone(url string) {
+func runClone(url string, failFast bool) {
 
 	if len(url) == 0 {
 		bob, err := bob.Bob(bob.WithRequireBobConfig())
 		errz.Fatal(err)
 
 		// Try to clone dependencies of current repo
-		err = bob.Clone()
+		err = bob.Clone(failFast)
 		errz.Fatal(err)
 
 		fmt.Printf("%s\n", aurora.Green("Cloned"))
@@ -40,8 +45,13 @@ func runClone(url string) {
 		errz.Fatal(err)
 
 		// Try to clone a new bob repo to the current working directory
-		repoName, err := bob.CloneRepo(url)
-		errz.Fatal(err)
+		repoName, err := bob.CloneRepo(url, failFast)
+		if errors.As(err, &usererror.Err) {
+			fmt.Printf("%s\n", aurora.Red(errors.Unwrap(err).Error()))
+			os.Exit(1)
+		} else {
+			errz.Fatal(err)
+		}
 
 		fmt.Printf("%s\n", aurora.Green(fmt.Sprintf("Cloned to %s", repoName)))
 	}

--- a/cli/cmd_root.go
+++ b/cli/cmd_root.go
@@ -25,8 +25,11 @@ func init() {
 	rootCmd.Flags().Bool("version", false, "Show the CLI's version")
 
 	rootCmd.AddCommand(verifyCmd)
-	rootCmd.AddCommand(CmdClone)
 	rootCmd.AddCommand(cleanCmd)
+
+	// clone
+	CmdClone.Flags().Bool("fail-fast", false, "Fail on first error without user prompt")
+	rootCmd.AddCommand(CmdClone)
 
 	// workspace
 	cmdAdd.Flags().Bool("plain", false, "Do not infer contrary protocol url")

--- a/cli/cmd_root.go
+++ b/cli/cmd_root.go
@@ -29,6 +29,8 @@ func init() {
 	rootCmd.AddCommand(cleanCmd)
 
 	// workspace
+	cmdAdd.Flags().Bool("https-only", false, "Set to true to use only https url for the repository")
+	cmdAdd.Flags().Bool("ssh-only", false, "Set to true to use only ssh for the repository")
 	cmdWorkspace.AddCommand(cmdWorkspaceNew)
 	cmdWorkspace.AddCommand(cmdAdd)
 	rootCmd.AddCommand(cmdWorkspace)

--- a/cli/cmd_root.go
+++ b/cli/cmd_root.go
@@ -29,7 +29,7 @@ func init() {
 	rootCmd.AddCommand(cleanCmd)
 
 	// workspace
-	cmdAdd.Flags().Bool("plain", false, "Don't infer contrary protocol url (git/https) from scheme")
+	cmdAdd.Flags().Bool("plain", false, "Do not infer contrary protocol url")
 	cmdWorkspace.AddCommand(cmdWorkspaceNew)
 	cmdWorkspace.AddCommand(cmdAdd)
 	rootCmd.AddCommand(cmdWorkspace)

--- a/cli/cmd_root.go
+++ b/cli/cmd_root.go
@@ -29,7 +29,7 @@ func init() {
 	rootCmd.AddCommand(cleanCmd)
 
 	// workspace
-	cmdAdd.Flags().Bool("explicit-protocol", false, "Set to repository protocol explicit to https/ssh depending on the given url")
+	cmdAdd.Flags().Bool("plain", false, "Don't infer contrary protocol url (git/https) from scheme")
 	cmdWorkspace.AddCommand(cmdWorkspaceNew)
 	cmdWorkspace.AddCommand(cmdAdd)
 	rootCmd.AddCommand(cmdWorkspace)

--- a/cli/cmd_root.go
+++ b/cli/cmd_root.go
@@ -29,8 +29,7 @@ func init() {
 	rootCmd.AddCommand(cleanCmd)
 
 	// workspace
-	cmdAdd.Flags().Bool("https-only", false, "Set to true to use only https url for the repository")
-	cmdAdd.Flags().Bool("ssh-only", false, "Set to true to use only ssh for the repository")
+	cmdAdd.Flags().Bool("explicit-protocol", false, "Set to repository protocol explicit to https/ssh depending on the given url")
 	cmdWorkspace.AddCommand(cmdWorkspaceNew)
 	cmdWorkspace.AddCommand(cmdAdd)
 	rootCmd.AddCommand(cmdWorkspace)

--- a/cli/cmd_workspace_add.go
+++ b/cli/cmd_workspace_add.go
@@ -16,13 +16,23 @@ var cmdAdd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
+		httpsOnly, err := cmd.Flags().GetBool("https-only")
+		errz.Fatal(err)
+
+		sshOnly, err := cmd.Flags().GetBool("ssh-only")
+		errz.Fatal(err)
+
 		repoURL := args[0]
-		runAdd(repoURL)
+		runAdd(repoURL, httpsOnly, sshOnly)
 	},
 }
 
-func runAdd(repoURL string) {
-	err := add.Add(repoURL)
+func runAdd(repoURL string, https bool, ssh bool) {
+	err := add.Add(
+		repoURL,
+		add.WithHttpsOnly(https),
+		add.WithSSHOnly(ssh),
+	)
 	errz.Fatal(err)
 
 	fmt.Printf("%s\n", aurora.Green("Repo added"))

--- a/cli/cmd_workspace_add.go
+++ b/cli/cmd_workspace_add.go
@@ -1,9 +1,13 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
+	"os"
 
 	"github.com/Benchkram/bob/pkg/add"
+	"github.com/Benchkram/bob/pkg/boblog"
+	"github.com/Benchkram/bob/pkg/usererror"
 	"github.com/Benchkram/errz"
 
 	"github.com/logrusorgru/aurora"
@@ -29,7 +33,13 @@ func runAdd(repoURL string, explcitprotcl bool) {
 		repoURL,
 		add.WithExplicitProtocol(explcitprotcl),
 	)
-	errz.Fatal(err)
+
+	if errors.As(err, &usererror.Err) {
+		boblog.Log.UserError(err)
+		os.Exit(1)
+	} else {
+		errz.Fatal(err)
+	}
 
 	fmt.Printf("%s\n", aurora.Green("Repo added"))
 }

--- a/cli/cmd_workspace_add.go
+++ b/cli/cmd_workspace_add.go
@@ -16,22 +16,18 @@ var cmdAdd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		httpsOnly, err := cmd.Flags().GetBool("https-only")
-		errz.Fatal(err)
-
-		sshOnly, err := cmd.Flags().GetBool("ssh-only")
+		explicit, err := cmd.Flags().GetBool("explicit-protocol")
 		errz.Fatal(err)
 
 		repoURL := args[0]
-		runAdd(repoURL, httpsOnly, sshOnly)
+		runAdd(repoURL, explicit)
 	},
 }
 
-func runAdd(repoURL string, https bool, ssh bool) {
+func runAdd(repoURL string, explcitprotcl bool) {
 	err := add.Add(
 		repoURL,
-		add.WithHttpsOnly(https),
-		add.WithSSHOnly(ssh),
+		add.WithExplicitProtocol(explcitprotcl),
 	)
 	errz.Fatal(err)
 

--- a/cli/cmd_workspace_add.go
+++ b/cli/cmd_workspace_add.go
@@ -20,18 +20,18 @@ var cmdAdd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		explicit, err := cmd.Flags().GetBool("explicit-protocol")
+		plain, err := cmd.Flags().GetBool("plain")
 		errz.Fatal(err)
 
 		repoURL := args[0]
-		runAdd(repoURL, explicit)
+		runAdd(repoURL, plain)
 	},
 }
 
-func runAdd(repoURL string, explcitprotcl bool) {
+func runAdd(repoURL string, plain bool) {
 	err := add.Add(
 		repoURL,
-		add.WithExplicitProtocol(explcitprotcl),
+		add.WithPlainProtocol(plain),
 	)
 
 	if errors.As(err, &usererror.Err) {

--- a/pkg/add/add.go
+++ b/pkg/add/add.go
@@ -5,13 +5,46 @@ import (
 	"github.com/Benchkram/errz"
 )
 
-func Add(repoURL string) (err error) {
+type AddParams struct {
+	repoUrl   string
+	httpsOnly bool
+	sshOnly   bool
+}
+
+type Option func(a *AddParams)
+
+func WithHttpsOnly(https bool) Option {
+	return func(a *AddParams) {
+		a.httpsOnly = https
+	}
+}
+
+func WithSSHOnly(ssh bool) Option {
+	return func(a *AddParams) {
+		a.sshOnly = ssh
+	}
+}
+
+func Add(repoURL string, opts ...Option) (err error) {
 	defer errz.Recover(&err)
 
 	bob, err := bob.Bob(bob.WithRequireBobConfig())
 	errz.Fatal(err)
 
-	err = bob.Add(repoURL)
+	params := &AddParams{
+		repoUrl:   repoURL,
+		httpsOnly: false,
+		sshOnly:   false,
+	}
+
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		opt(params)
+	}
+
+	err = bob.Add(params.repoUrl, params.httpsOnly, params.sshOnly)
 	errz.Fatal(err)
 
 	return nil

--- a/pkg/add/add.go
+++ b/pkg/add/add.go
@@ -6,15 +6,15 @@ import (
 )
 
 type AddParams struct {
-	repoUrl  string
-	explicit bool
+	repoUrl string
+	plain   bool
 }
 
 type Option func(a *AddParams)
 
-func WithExplicitProtocol(explicit bool) Option {
+func WithPlainProtocol(explicit bool) Option {
 	return func(a *AddParams) {
-		a.explicit = explicit
+		a.plain = explicit
 	}
 }
 
@@ -25,8 +25,8 @@ func Add(repoURL string, opts ...Option) (err error) {
 	errz.Fatal(err)
 
 	params := &AddParams{
-		repoUrl:  repoURL,
-		explicit: false,
+		repoUrl: repoURL,
+		plain:   false,
 	}
 
 	for _, opt := range opts {
@@ -36,7 +36,7 @@ func Add(repoURL string, opts ...Option) (err error) {
 		opt(params)
 	}
 
-	err = bob.Add(params.repoUrl, params.explicit)
+	err = bob.Add(params.repoUrl, params.plain)
 	errz.Fatal(err)
 
 	return nil

--- a/pkg/add/add.go
+++ b/pkg/add/add.go
@@ -6,22 +6,15 @@ import (
 )
 
 type AddParams struct {
-	repoUrl   string
-	httpsOnly bool
-	sshOnly   bool
+	repoUrl  string
+	explicit bool
 }
 
 type Option func(a *AddParams)
 
-func WithHttpsOnly(https bool) Option {
+func WithExplicitProtocol(explicit bool) Option {
 	return func(a *AddParams) {
-		a.httpsOnly = https
-	}
-}
-
-func WithSSHOnly(ssh bool) Option {
-	return func(a *AddParams) {
-		a.sshOnly = ssh
+		a.explicit = explicit
 	}
 }
 
@@ -32,9 +25,8 @@ func Add(repoURL string, opts ...Option) (err error) {
 	errz.Fatal(err)
 
 	params := &AddParams{
-		repoUrl:   repoURL,
-		httpsOnly: false,
-		sshOnly:   false,
+		repoUrl:  repoURL,
+		explicit: false,
 	}
 
 	for _, opt := range opts {
@@ -44,7 +36,7 @@ func Add(repoURL string, opts ...Option) (err error) {
 		opt(params)
 	}
 
-	err = bob.Add(params.repoUrl, params.httpsOnly, params.sshOnly)
+	err = bob.Add(params.repoUrl, params.explicit)
 	errz.Fatal(err)
 
 	return nil

--- a/pkg/cmdutil/run.go
+++ b/pkg/cmdutil/run.go
@@ -11,6 +11,7 @@ import (
 type Runnable interface {
 	Run() error
 	Output() ([]byte, error)
+	OutputCombined() ([]byte, error)
 }
 
 type run struct {
@@ -50,6 +51,23 @@ func (run *run) Output() ([]byte, error) {
 	return output, nil
 }
 
+func (run *run) OutputCombined() ([]byte, error) {
+	var b bytes.Buffer
+	run.cmd.Stdout = &b
+	run.cmd.Stderr = &b
+
+	err := run.cmd.Run()
+	if err != nil {
+		return nil, CmdError{
+			Stderr: &b,
+			Args:   run.cmd.Args,
+			Err:    err,
+		}
+	}
+
+	return b.Bytes(), nil
+}
+
 // gitprepare inits git cmd with `root` as the working dir.
 func gitprepare(root string, args ...string) (r Runnable, _ error) {
 	cmd, err := git.GitCommand(args...)
@@ -68,6 +86,14 @@ func RunGit(root string, args ...string) error {
 		return err
 	}
 	return r.Run()
+}
+
+func RunGitWithOutput(root string, args ...string) ([]byte, error) {
+	r, err := gitprepare(root, args...)
+	if err != nil {
+		return nil, err
+	}
+	return r.OutputCombined()
 }
 
 func GitStatus(root string) ([]byte, error) {

--- a/test/e2e/add/add_test.go
+++ b/test/e2e/add/add_test.go
@@ -28,7 +28,6 @@ var _ = Describe("Test bob add", func() {
 
 		It("adds local repos to bob", func() {
 			for _, child := range childs {
-				fmt.Println(child)
 				Expect(b.Add(fmt.Sprintf("file://%s", child), false)).NotTo(HaveOccurred())
 			}
 		})
@@ -45,22 +44,9 @@ var _ = Describe("Test bob add", func() {
 			Expect(b.Add("", true)).To(HaveOccurred())
 		})
 
-		It("adds Empty https url, must be failed", func() {
+		It("adds Empty https url, does not fail with strings starts with valid protocol", func() {
 			err := b.Add("https://", true)
-			Expect(err).To(HaveOccurred())
-			Expect(errors.Is(err, bob.ErrInvalidURL)).To(BeTrue())
-		})
-
-		It("adds Empty git url, must return Invalid URL error", func() {
-			err := b.Add("git@", true)
-			Expect(err).To(HaveOccurred())
-			Expect(errors.Is(err, bob.ErrInvalidURL)).To(BeTrue())
-		})
-
-		It("Invalid https url without .git on its end, must be failed", func() {
-			err := b.Add("https://github.com/pkg/browser", false)
-			Expect(err).To(HaveOccurred())
-			Expect(errors.Is(err, bob.ErrInvalidURL)).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("verifies that adding a duplicate repo fails on a new bob instance", func() {

--- a/test/e2e/add/add_test.go
+++ b/test/e2e/add/add_test.go
@@ -19,16 +19,16 @@ var _ = Describe("Test bob add", func() {
 		})
 
 		It("adds HTTPS repo to bob", func() {
-			Expect(b.Add("https://github.com/pkg/errors.git")).NotTo(HaveOccurred())
+			Expect(b.Add("https://github.com/pkg/errors.git", false, false)).NotTo(HaveOccurred())
 		})
 
 		It("adds SSH repo to bob", func() {
-			Expect(b.Add("git@github.com:Benchkram/bob.git")).NotTo(HaveOccurred())
+			Expect(b.Add("git@github.com:Benchkram/bob.git", false, false)).NotTo(HaveOccurred())
 		})
 
 		It("adds local repos to bob", func() {
 			for _, child := range childs {
-				Expect(b.Add(fmt.Sprintf("file://%s", child))).NotTo(HaveOccurred())
+				Expect(b.Add(fmt.Sprintf("file://%s", child), false, false)).NotTo(HaveOccurred())
 			}
 		})
 

--- a/test/e2e/add/add_test.go
+++ b/test/e2e/add/add_test.go
@@ -19,16 +19,16 @@ var _ = Describe("Test bob add", func() {
 		})
 
 		It("adds HTTPS repo to bob", func() {
-			Expect(b.Add("https://github.com/pkg/errors.git", false, false)).NotTo(HaveOccurred())
+			Expect(b.Add("https://github.com/pkg/errors.git", false)).NotTo(HaveOccurred())
 		})
 
 		It("adds SSH repo to bob", func() {
-			Expect(b.Add("git@github.com:Benchkram/bob.git", false, false)).NotTo(HaveOccurred())
+			Expect(b.Add("git@github.com:Benchkram/bob.git", false)).NotTo(HaveOccurred())
 		})
 
 		It("adds local repos to bob", func() {
 			for _, child := range childs {
-				Expect(b.Add(fmt.Sprintf("file://%s", child), false, false)).NotTo(HaveOccurred())
+				Expect(b.Add(fmt.Sprintf("file://%s", child), false)).NotTo(HaveOccurred())
 			}
 		})
 

--- a/test/e2e/add/add_test.go
+++ b/test/e2e/add/add_test.go
@@ -33,11 +33,11 @@ var _ = Describe("Test bob add", func() {
 			}
 		})
 
-		It("adds HTTPS repo to bob, with explicit protocol", func() {
+		It("adds HTTPS repo to bob, with plain protocol", func() {
 			Expect(b.Add("https://github.com/pkg/requests.git", true)).NotTo(HaveOccurred())
 		})
 
-		It("adds SSH repo to bob, with explicit protocol", func() {
+		It("adds SSH repo to bob, with plain protocol", func() {
 			Expect(b.Add("git@github.com:pkg/exec.git", true)).NotTo(HaveOccurred())
 		})
 
@@ -58,7 +58,7 @@ var _ = Describe("Test bob add", func() {
 		})
 
 		It("Invalid https url without .git on its end, must be failed", func() {
-			err := b.Add("https://github.com/pkg/browser", true)
+			err := b.Add("https://github.com/pkg/browser", false)
 			Expect(err).To(HaveOccurred())
 			Expect(errors.Is(err, bob.ErrInvalidURL)).To(BeTrue())
 		})

--- a/test/e2e/add/add_test.go
+++ b/test/e2e/add/add_test.go
@@ -33,11 +33,11 @@ var _ = Describe("Test bob add", func() {
 		})
 
 		It("adds HTTPS repo to bob, with explicit protocol", func() {
-			Expect(b.Add("https://github.com/derekmolloy/test.git", true)).NotTo(HaveOccurred())
+			Expect(b.Add("https://github.com/pkg/requests", true)).NotTo(HaveOccurred())
 		})
 
 		It("adds SSH repo to bob, with explicit protocol", func() {
-			Expect(b.Add("git@github.com:zpqrtbnk/test-repo.git", true)).NotTo(HaveOccurred())
+			Expect(b.Add("git@github.com:pkg/exec.git", true)).NotTo(HaveOccurred())
 		})
 
 		It("verifies that adding a duplicate repo fails on a new bob instance", func() {

--- a/test/e2e/add/add_test.go
+++ b/test/e2e/add/add_test.go
@@ -28,16 +28,39 @@ var _ = Describe("Test bob add", func() {
 
 		It("adds local repos to bob", func() {
 			for _, child := range childs {
+				fmt.Println(child)
 				Expect(b.Add(fmt.Sprintf("file://%s", child), false)).NotTo(HaveOccurred())
 			}
 		})
 
 		It("adds HTTPS repo to bob, with explicit protocol", func() {
-			Expect(b.Add("https://github.com/pkg/requests", true)).NotTo(HaveOccurred())
+			Expect(b.Add("https://github.com/pkg/requests.git", true)).NotTo(HaveOccurred())
 		})
 
 		It("adds SSH repo to bob, with explicit protocol", func() {
 			Expect(b.Add("git@github.com:pkg/exec.git", true)).NotTo(HaveOccurred())
+		})
+
+		It("adds Empty url, must be failed", func() {
+			Expect(b.Add("", true)).To(HaveOccurred())
+		})
+
+		It("adds Empty https url, must be failed", func() {
+			err := b.Add("https://", true)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, bob.ErrInvalidURL)).To(BeTrue())
+		})
+
+		It("adds Empty git url, must return Invalid URL error", func() {
+			err := b.Add("git@", true)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, bob.ErrInvalidURL)).To(BeTrue())
+		})
+
+		It("Invalid https url without .git on its end, must be failed", func() {
+			err := b.Add("https://github.com/pkg/browser", true)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, bob.ErrInvalidURL)).To(BeTrue())
 		})
 
 		It("verifies that adding a duplicate repo fails on a new bob instance", func() {

--- a/test/e2e/add/add_test.go
+++ b/test/e2e/add/add_test.go
@@ -32,6 +32,14 @@ var _ = Describe("Test bob add", func() {
 			}
 		})
 
+		It("adds HTTPS repo to bob, with explicit protocol", func() {
+			Expect(b.Add("https://github.com/derekmolloy/test.git", true)).NotTo(HaveOccurred())
+		})
+
+		It("adds SSH repo to bob, with explicit protocol", func() {
+			Expect(b.Add("git@github.com:zpqrtbnk/test-repo.git", true)).NotTo(HaveOccurred())
+		})
+
 		It("verifies that adding a duplicate repo fails on a new bob instance", func() {
 			owd, err := os.Getwd()
 			Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/add/add_test.go
+++ b/test/e2e/add/add_test.go
@@ -19,21 +19,21 @@ var _ = Describe("Test bob add", func() {
 			Expect(b.Init()).NotTo(HaveOccurred())
 		})
 
-		It("adds HTTPS repo to bob", func() {
+		It("should add https repo to bob", func() {
 			Expect(b.Add("https://github.com/pkg/errors.git", false)).NotTo(HaveOccurred())
 		})
 
-		It("adds SSH repo to bob", func() {
+		It("should adds ssh repo to bob", func() {
 			Expect(b.Add("git@github.com:Benchkram/bob.git", false)).NotTo(HaveOccurred())
 		})
 
-		It("adds local repos to bob", func() {
+		It("should add local repo to bob", func() {
 			for _, child := range childs {
 				Expect(b.Add(fmt.Sprintf("file://%s", child), false)).NotTo(HaveOccurred())
 			}
 		})
 
-		It("adds HTTPS repo to bob, with plain protocol", func() {
+		It("should add https repo to bob, without infering ssh url ", func() {
 			targeturl := "https://github.com/pkg/requests.git"
 			Expect(b.Add(targeturl, true)).NotTo(HaveOccurred())
 
@@ -45,7 +45,7 @@ var _ = Describe("Test bob add", func() {
 			Expect(repo.HTTPSUrl).To(Equal(targeturl))
 		})
 
-		It("adds SSH repo to bob, with plain protocol", func() {
+		It("should add ssh repo to bob, without infering https url", func() {
 			targeturl := "git@github.com:pkg/exec.git"
 			Expect(b.Add(targeturl, true)).NotTo(HaveOccurred())
 
@@ -57,16 +57,16 @@ var _ = Describe("Test bob add", func() {
 			Expect(repo.SSHUrl).To(Equal(targeturl))
 		})
 
-		It("adds Empty url, must be failed", func() {
+		It("should fail adding a empty url", func() {
 			Expect(b.Add("", true)).To(HaveOccurred())
 		})
 
-		It("adds Empty https url, does not fail with strings starts with valid protocol", func() {
-			err := b.Add("https://", true)
-			Expect(err).NotTo(HaveOccurred())
-		})
+		// It("should fail due to invalid repo name, ", func() {
+		// 	err := b.Add("https://", true)
+		// 	Expect(err).To(HaveOccurred())
+		// })
 
-		It("verifies that adding a duplicate repo fails on a new bob instance", func() {
+		It("should verify that adding a duplicate repo fails", func() {
 			owd, err := os.Getwd()
 			Expect(err).NotTo(HaveOccurred())
 			err = os.Chdir(b.Dir())

--- a/test/e2e/clone/clone_test.go
+++ b/test/e2e/clone/clone_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Test bob clone", func() {
 		})
 
 		It("adds HTTPS repo to bob", func() {
-			Expect(b.Add("https://github.com/pkg/errors.git")).NotTo(HaveOccurred())
+			Expect(b.Add("https://github.com/pkg/errors.git", false, false)).NotTo(HaveOccurred())
 		})
 
 		// TODO: Reenable. Fails to clone on CI.
@@ -31,11 +31,11 @@ var _ = Describe("Test bob clone", func() {
 		It("adds local repos to bob", func() {
 			// Children
 			for _, child := range childs {
-				Expect(b.Add(fmt.Sprintf("file://%s", child))).NotTo(HaveOccurred())
+				Expect(b.Add(fmt.Sprintf("file://%s", child), false, false)).NotTo(HaveOccurred())
 			}
 
 			// Recursive
-			Expect(b.Add(fmt.Sprintf("file://%s", recursiveRepo))).NotTo(HaveOccurred())
+			Expect(b.Add(fmt.Sprintf("file://%s", recursiveRepo), false, false)).NotTo(HaveOccurred())
 		})
 
 		It("runs bob clone", func() {

--- a/test/e2e/clone/clone_test.go
+++ b/test/e2e/clone/clone_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Test bob clone", func() {
 
 		// TODO: Reenable. Fails to clone on CI.
 		/*It("adds SSH repo to bob", func() {
-			Expect(b.Add("git@github.com:Benchkram/bob.git")).NotTo(HaveOccurred())
+			Expect(b.Add("git@github.com:Benchkram/bob.git", false)).NotTo(HaveOccurred())
 		})*/
 
 		It("adds local repos to bob", func() {
@@ -40,12 +40,12 @@ var _ = Describe("Test bob clone", func() {
 
 		// adds https repo with explicit https url for cloning
 		It("adds HTTPS repo to bob, with explicit protocol", func() {
-			Expect(b.Add("https://github.com/derekmolloy/test.git", true)).NotTo(HaveOccurred())
+			Expect(b.Add("https://github.com/pkg/requests", true)).NotTo(HaveOccurred())
 		})
 
 		// adds git repo with explicit ssh url for cloning
 		It("adds SSH repo to bob, with explicit protocol", func() {
-			Expect(b.Add("git@github.com:zpqrtbnk/test-repo.git", true)).NotTo(HaveOccurred())
+			Expect(b.Add("git@github.com:pkg/exec.git", true)).NotTo(HaveOccurred())
 		})
 
 		It("runs bob clone", func() {

--- a/test/e2e/clone/clone_test.go
+++ b/test/e2e/clone/clone_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Test bob clone", func() {
 		})
 
 		It("adds HTTPS repo to bob", func() {
-			Expect(b.Add("https://github.com/pkg/errors.git", false, false)).NotTo(HaveOccurred())
+			Expect(b.Add("https://github.com/pkg/errors.git", false)).NotTo(HaveOccurred())
 		})
 
 		// TODO: Reenable. Fails to clone on CI.
@@ -31,11 +31,11 @@ var _ = Describe("Test bob clone", func() {
 		It("adds local repos to bob", func() {
 			// Children
 			for _, child := range childs {
-				Expect(b.Add(fmt.Sprintf("file://%s", child), false, false)).NotTo(HaveOccurred())
+				Expect(b.Add(fmt.Sprintf("file://%s", child), false)).NotTo(HaveOccurred())
 			}
 
 			// Recursive
-			Expect(b.Add(fmt.Sprintf("file://%s", recursiveRepo), false, false)).NotTo(HaveOccurred())
+			Expect(b.Add(fmt.Sprintf("file://%s", recursiveRepo), false)).NotTo(HaveOccurred())
 		})
 
 		It("runs bob clone", func() {

--- a/test/e2e/clone/clone_test.go
+++ b/test/e2e/clone/clone_test.go
@@ -38,8 +38,8 @@ var _ = Describe("Test bob clone", func() {
 			Expect(b.Add(fmt.Sprintf("file://%s", recursiveRepo), false)).NotTo(HaveOccurred())
 		})
 
-		// adds https repo with explicit https url for cloning
-		It("adds HTTPS repo to bob, with explicit protocol", func() {
+		// adds https repo with plain https url for cloning
+		It("adds HTTPS repo to bob, with plain protocol", func() {
 			Expect(b.Add("https://github.com/pkg/requests.git", true)).NotTo(HaveOccurred())
 		})
 

--- a/test/e2e/clone/clone_test.go
+++ b/test/e2e/clone/clone_test.go
@@ -38,6 +38,16 @@ var _ = Describe("Test bob clone", func() {
 			Expect(b.Add(fmt.Sprintf("file://%s", recursiveRepo), false)).NotTo(HaveOccurred())
 		})
 
+		// adds https repo with explicit https url for cloning
+		It("adds HTTPS repo to bob, with explicit protocol", func() {
+			Expect(b.Add("https://github.com/derekmolloy/test.git", true)).NotTo(HaveOccurred())
+		})
+
+		// adds git repo with explicit ssh url for cloning
+		It("adds SSH repo to bob, with explicit protocol", func() {
+			Expect(b.Add("git@github.com:zpqrtbnk/test-repo.git", true)).NotTo(HaveOccurred())
+		})
+
 		It("runs bob clone", func() {
 			Expect(b.Clone()).NotTo(HaveOccurred())
 

--- a/test/e2e/clone/clone_test.go
+++ b/test/e2e/clone/clone_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Test bob clone", func() {
 		// })
 
 		It("runs bob clone", func() {
-			Expect(b.Clone()).NotTo(HaveOccurred())
+			Expect(b.Clone(true)).NotTo(HaveOccurred())
 
 			// Children
 			for _, child := range reposetup.Childs {
@@ -66,7 +66,7 @@ var _ = Describe("Test bob clone", func() {
 		})
 
 		It("runs bob clone to clone a bob repo", func() {
-			_, err := b.CloneRepo(fmt.Sprintf("file://%s", playgroundRepo))
+			_, err := b.CloneRepo(fmt.Sprintf("file://%s", playgroundRepo), true)
 			Expect(err).NotTo(HaveOccurred())
 
 			f := filepath.Join(playgroundRepo, "second-level", "third-level", global.BobFileName)
@@ -74,7 +74,7 @@ var _ = Describe("Test bob clone", func() {
 		})
 
 		It("runs bob clone to clone a bob repo recursively", func() {
-			_, err := b.CloneRepo(fmt.Sprintf("file://%s", recursiveRepo))
+			_, err := b.CloneRepo(fmt.Sprintf("file://%s", recursiveRepo), true)
 			Expect(err).NotTo(HaveOccurred())
 
 			childProjectGit := filepath.Join(top, reposetup.ChildRecursive, "errors", ".git")

--- a/test/e2e/clone/clone_test.go
+++ b/test/e2e/clone/clone_test.go
@@ -43,10 +43,11 @@ var _ = Describe("Test bob clone", func() {
 			Expect(b.Add("https://github.com/pkg/requests", true)).NotTo(HaveOccurred())
 		})
 
+		// TODO: Fails to clone on CI.
 		// adds git repo with explicit ssh url for cloning
-		It("adds SSH repo to bob, with explicit protocol", func() {
-			Expect(b.Add("git@github.com:pkg/exec.git", true)).NotTo(HaveOccurred())
-		})
+		// It("adds SSH repo to bob, with explicit protocol", func() {
+		// 	Expect(b.Add("git@github.com:pkg/exec.git", true)).NotTo(HaveOccurred())
+		// })
 
 		It("runs bob clone", func() {
 			Expect(b.Clone()).NotTo(HaveOccurred())

--- a/test/e2e/clone/clone_test.go
+++ b/test/e2e/clone/clone_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Test bob clone", func() {
 
 		// adds https repo with explicit https url for cloning
 		It("adds HTTPS repo to bob, with explicit protocol", func() {
-			Expect(b.Add("https://github.com/pkg/requests", true)).NotTo(HaveOccurred())
+			Expect(b.Add("https://github.com/pkg/requests.git", true)).NotTo(HaveOccurred())
 		})
 
 		// TODO: Fails to clone on CI.

--- a/test/e2e/clone/clone_test.go
+++ b/test/e2e/clone/clone_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Test bob clone", func() {
 		})
 
 		It("adds HTTPS repo to bob", func() {
-			Expect(b.Add("https://github.com/pkg/errors.git", false)).NotTo(HaveOccurred())
+			Expect(b.Add("https://github.com/pkg/errors.git", true)).NotTo(HaveOccurred())
 		})
 
 		// TODO: Reenable. Fails to clone on CI.

--- a/test/setup/reposetup/setup_structure.go
+++ b/test/setup/reposetup/setup_structure.go
@@ -78,7 +78,7 @@ func RecursiveRepo(basePath string) (_ string, err error) {
 	err = b.Init()
 	errz.Fatal(err)
 
-	err = b.Add("https://github.com/pkg/errors.git", false, false)
+	err = b.Add("https://github.com/pkg/errors.git", false)
 	errz.Fatal(err)
 
 	repo, err := git.PlainOpen(path)

--- a/test/setup/reposetup/setup_structure.go
+++ b/test/setup/reposetup/setup_structure.go
@@ -78,7 +78,7 @@ func RecursiveRepo(basePath string) (_ string, err error) {
 	err = b.Init()
 	errz.Fatal(err)
 
-	err = b.Add("https://github.com/pkg/errors.git")
+	err = b.Add("https://github.com/pkg/errors.git", false, false)
 	errz.Fatal(err)
 
 	repo, err := git.PlainOpen(path)

--- a/test/setup/reposetup/setup_structure.go
+++ b/test/setup/reposetup/setup_structure.go
@@ -78,7 +78,7 @@ func RecursiveRepo(basePath string) (_ string, err error) {
 	err = b.Init()
 	errz.Fatal(err)
 
-	err = b.Add("https://github.com/pkg/errors.git", false)
+	err = b.Add("https://github.com/pkg/errors.git", true)
 	errz.Fatal(err)
 
 	repo, err := git.PlainOpen(path)


### PR DESCRIPTION
- bob clone with git outputs print
- bob clone directory with the same name issues on the parent directory
- add `explicit-protocol` flag on `bob workspace add` to set the URL explicitly to the provided protocol
- add tests for `explicit-protocol` flag