### PR TITLE
cli speed improvements - completion

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Run tests
         run: | 
-          # go get github.com/jbenet/go-context/io@v0.0.0-20150711004518-d14ea06fba99
+          go get github.com/jbenet/go-context/io@v0.0.0-20150711004518-d14ea06fba99
           # go get github.com/go-git/go-git/v5/plumbing/transport/ssh@v5.4.2
           # go get golang.org/x/net/idna@v0.0.0-20211015210444-4f30a5c0130f
           # go get github.com/AlecAivazis/survey/v2/terminal@v2.2.9

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,5 +58,4 @@ jobs:
       - name: Run tests
         run: | 
           go get github.com/jbenet/go-context/io@v0.0.0-20150711004518-d14ea06fba99
-          which ginkgo
-          ginkgo -v ./...
+          go test -v ./...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,16 +46,9 @@ jobs:
       - name: Build
         run: make build
 
-      - name: Install ginkgo
-        run: go get -u github.com/onsi/ginkgo/ginkgo
-
       - name: Set Git author name and email address
         run: git config --global user.name "Bob The Builder" && git config --global user.email "bob@thebuilder.com"
           
-          # go get github.com/go-git/go-git/v5/plumbing/transport/ssh@v5.4.2
-          # go get golang.org/x/net/idna@v0.0.0-20211015210444-4f30a5c0130f
-          # go get github.com/AlecAivazis/survey/v2/terminal@v2.2.9
       - name: Run tests
         run: | 
-          go get github.com/jbenet/go-context/io@v0.0.0-20150711004518-d14ea06fba99
           go test -v ./...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,11 +51,12 @@ jobs:
 
       - name: Set Git author name and email address
         run: git config --global user.name "Bob The Builder" && git config --global user.email "bob@thebuilder.com"
-
-      - name: Run tests
-        run: | 
-          go get github.com/jbenet/go-context/io@v0.0.0-20150711004518-d14ea06fba99
+          
           # go get github.com/go-git/go-git/v5/plumbing/transport/ssh@v5.4.2
           # go get golang.org/x/net/idna@v0.0.0-20211015210444-4f30a5c0130f
           # go get github.com/AlecAivazis/survey/v2/terminal@v2.2.9
+      - name: Run tests
+        run: | 
+          go get github.com/jbenet/go-context/io@v0.0.0-20150711004518-d14ea06fba99
+          which ginkgo
           ginkgo -v ./...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,8 +54,8 @@ jobs:
 
       - name: Run tests
         run: | 
-          go get github.com/jbenet/go-context/io@v0.0.0-20150711004518-d14ea06fba99
-          go get github.com/go-git/go-git/v5/plumbing/transport/ssh@v5.4.2
-          go get golang.org/x/net/idna@v0.0.0-20211015210444-4f30a5c0130f
-          go get github.com/AlecAivazis/survey/v2/terminal@v2.2.9
+          # go get github.com/jbenet/go-context/io@v0.0.0-20150711004518-d14ea06fba99
+          # go get github.com/go-git/go-git/v5/plumbing/transport/ssh@v5.4.2
+          # go get golang.org/x/net/idna@v0.0.0-20211015210444-4f30a5c0130f
+          # go get github.com/AlecAivazis/survey/v2/terminal@v2.2.9
           ginkgo -v ./...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.7
+          go-version: 1.18
 
 
       # Check if there are any changes for 'go mod tidy'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       #     git diff --exit-code go.mod
 
       - name: Install golangci-lint
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.41.1
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.45.2
 
       - name: Lint code
         run: make lint

--- a/bob/aggregate.go
+++ b/bob/aggregate.go
@@ -59,8 +59,15 @@ func (b *B) PrintVersionCompatibility(bobfile *bobfile.Bobfile) {
 
 // AggregateSparse reads Bobfile with the intent to gather task names.
 // The returned bobfile is not ready to be executed with a playbook.
-func (b *B) AggregateSparse() (aggregate *bobfile.Bobfile, err error) {
+func (b *B) AggregateSparse(omitRunTasks ...bool) (aggregate *bobfile.Bobfile, err error) {
 	defer errz.Recover(&err)
+
+	addRunTasks := true
+	if len(omitRunTasks) > 0 {
+		if omitRunTasks[0] {
+			addRunTasks = false
+		}
+	}
 
 	bobfiles, err := b.find()
 	errz.Fatal(err)
@@ -88,6 +95,10 @@ func (b *B) AggregateSparse() (aggregate *bobfile.Bobfile, err error) {
 
 	// Merge tasks into one Bobfile
 	aggregate = b.addBuildTasksToAggregate(aggregate, bobs)
+
+	if addRunTasks {
+		aggregate = b.addRunTasksToAggregate(aggregate, bobs)
+	}
 
 	return aggregate, nil
 }

--- a/bob/aggregate_util.go
+++ b/bob/aggregate_util.go
@@ -1,0 +1,98 @@
+package bob
+
+import (
+	"strings"
+
+	"github.com/benchkram/bob/bob/bobfile"
+)
+
+// syncProjectName project names for all bobfiles and build tasks
+func syncProjectName(
+	a *bobfile.Bobfile,
+	bobs []*bobfile.Bobfile,
+) (*bobfile.Bobfile, []*bobfile.Bobfile) {
+	for _, bobfile := range bobs {
+		bobfile.Project = a.Project
+
+		for taskname, task := range bobfile.BTasks {
+			// Should be the name of the umbrella-bobfile.
+			task.SetProject(a.Project)
+
+			// Overwrite value in build map
+			bobfile.BTasks[taskname] = task
+		}
+	}
+
+	return a, bobs
+}
+
+func (b *B) addBuildTasksToAggregate(
+	a *bobfile.Bobfile,
+	bobs []*bobfile.Bobfile,
+) *bobfile.Bobfile {
+
+	for _, bobfile := range bobs {
+		// Skip the aggregate
+		if bobfile.Dir() == a.Dir() {
+			continue
+		}
+
+		for taskname, task := range bobfile.BTasks {
+			dir := bobfile.Dir()
+
+			// Use a relative path as task prefix.
+			prefix := strings.TrimPrefix(dir, b.dir)
+			taskname := addTaskPrefix(prefix, taskname)
+
+			// Alter the taskname.
+			task.SetName(taskname)
+
+			// Rewrite dependent tasks to global scope.
+			dependsOn := []string{}
+			for _, dependentTask := range task.DependsOn {
+				dependsOn = append(dependsOn, addTaskPrefix(prefix, dependentTask))
+			}
+			task.DependsOn = dependsOn
+
+			a.BTasks[taskname] = task
+		}
+	}
+
+	return a
+}
+
+func (b *B) addRunTasksToAggregate(
+	a *bobfile.Bobfile,
+	bobs []*bobfile.Bobfile,
+) *bobfile.Bobfile {
+
+	for _, bobfile := range bobs {
+		// Skip the aggregate
+		if bobfile.Dir() == a.Dir() {
+			continue
+		}
+
+		for runname, run := range bobfile.RTasks {
+			dir := bobfile.Dir()
+
+			// Use a relative path as task prefix.
+			prefix := strings.TrimPrefix(dir, b.dir)
+
+			runname = addTaskPrefix(prefix, runname)
+
+			// Alter the runname.
+			run.SetName(runname)
+
+			// Rewrite dependents to global scope.
+			dependsOn := []string{}
+			for _, dependent := range run.DependsOn {
+				dependsOn = append(dependsOn, addTaskPrefix(prefix, dependent))
+			}
+			run.DependsOn = dependsOn
+
+			a.RTasks[runname] = run
+		}
+	}
+
+	return a
+}

--- a/bob/bobfile/bobfile.go
+++ b/bob/bobfile/bobfile.go
@@ -164,6 +164,20 @@ func BobfileRead(dir string) (_ *Bobfile, err error) {
 	return b, b.BTasks.Sanitize()
 }
 
+// BobfileReadPlain reads a bobfile.
+// For performance reasons sanitize is not called.
+func BobfileReadPlain(dir string) (_ *Bobfile, err error) {
+	defer errz.Recover(&err)
+
+	b, err := bobfileRead(dir)
+	errz.Fatal(err)
+
+	err = b.Validate()
+	errz.Fatal(err)
+
+	return b, nil
+}
+
 // Validate makes sure no task depends on itself (self-reference) or has the same name as another task
 func (b *Bobfile) Validate() (err error) {
 	if b.Version != "" {

--- a/bob/build_list.go
+++ b/bob/build_list.go
@@ -23,7 +23,7 @@ func (b *B) List() (err error) {
 func (b *B) GetList() (tasks []string, err error) {
 	defer errz.Recover(&err)
 
-	aggregate, err := b.Aggregate()
+	aggregate, err := b.AggregateSparse()
 	errz.Fatal(err)
 
 	keys := make([]string, 0, len(aggregate.BTasks))

--- a/bob/build_list.go
+++ b/bob/build_list.go
@@ -1,29 +1,16 @@
 package bob
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/benchkram/errz"
 )
 
-func (b *B) List() (err error) {
+func (b *B) GetBuildTasks() (tasks []string, err error) {
 	defer errz.Recover(&err)
 
-	keys, err := b.GetList()
-	errz.Fatal(err)
-
-	for _, k := range keys {
-		fmt.Println(k)
-	}
-
-	return nil
-}
-
-func (b *B) GetList() (tasks []string, err error) {
-	defer errz.Recover(&err)
-
-	aggregate, err := b.AggregateSparse()
+	omitRunTasks := true
+	aggregate, err := b.AggregateSparse(omitRunTasks)
 	errz.Fatal(err)
 
 	keys := make([]string, 0, len(aggregate.BTasks))

--- a/bob/run_list.go
+++ b/bob/run_list.go
@@ -1,29 +1,15 @@
 package bob
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/benchkram/errz"
 )
 
-func (b *B) RunList() (err error) {
+func (b *B) GetRunTasks() (tasks []string, err error) {
 	defer errz.Recover(&err)
 
-	keys, err := b.GetRunList()
-	errz.Fatal(err)
-
-	for _, k := range keys {
-		fmt.Println(k)
-	}
-
-	return nil
-}
-
-func (b *B) GetRunList() (tasks []string, err error) {
-	defer errz.Recover(&err)
-
-	aggregate, err := b.Aggregate()
+	aggregate, err := b.AggregateSparse()
 	errz.Fatal(err)
 
 	keys := make([]string, 0, len(aggregate.RTasks))

--- a/cli/cmd_build.go
+++ b/cli/cmd_build.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"os/signal"
 	"strconv"
@@ -120,19 +119,4 @@ func getTasks() ([]string, error) {
 		return nil, err
 	}
 	return b.GetList()
-}
-
-// getTasksCmd cmd help to profile cli completion
-var getTasksCmd = &cobra.Command{
-	Use:   "gettasks",
-	Short: "gettasks",
-	Long:  ``,
-	Run: func(cmd *cobra.Command, args []string) {
-		tasks, err := getTasks()
-		errz.Log(err)
-
-		for _, t := range tasks {
-			fmt.Println(t)
-		}
-	},
 }

--- a/cli/cmd_build.go
+++ b/cli/cmd_build.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/signal"
 	"strconv"
@@ -42,7 +43,7 @@ var buildCmd = &cobra.Command{
 		runBuild(dummy, taskname, noCache)
 	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		tasks, err := getTasks()
+		tasks, err := getBuildTasks()
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}
@@ -109,14 +110,18 @@ func runBuildList() {
 	b, err := bob.Bob()
 	boblog.Log.Error(err, "Unable to initialize bob")
 
-	err = b.List()
+	tasks, err := b.GetBuildTasks()
 	boblog.Log.Error(err, "Unable to aggregate bob file")
+
+	for _, t := range tasks {
+		fmt.Println(t)
+	}
 }
 
-func getTasks() ([]string, error) {
+func getBuildTasks() ([]string, error) {
 	b, err := bob.Bob()
 	if err != nil {
 		return nil, err
 	}
-	return b.GetList()
+	return b.GetBuildTasks()
 }

--- a/cli/cmd_build.go
+++ b/cli/cmd_build.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/signal"
 	"strconv"
@@ -119,4 +120,19 @@ func getTasks() ([]string, error) {
 		return nil, err
 	}
 	return b.GetList()
+}
+
+// getTasksCmd cmd help to profile cli completion
+var getTasksCmd = &cobra.Command{
+	Use:   "gettasks",
+	Short: "gettasks",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		tasks, err := getTasks()
+		errz.Log(err)
+
+		for _, t := range tasks {
+			fmt.Println(t)
+		}
+	},
 }

--- a/cli/cmd_gettasks.go
+++ b/cli/cmd_gettasks.go
@@ -1,0 +1,31 @@
+//go:build dev
+// +build dev
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/benchkram/errz"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(getTasksCmd)
+}
+
+// getTasksCmd cmd help to profile cli completion
+var getTasksCmd = &cobra.Command{
+	Use:   "gettasks",
+	Short: "gettasks",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		tasks, err := getTasks()
+		errz.Log(err)
+
+		for _, t := range tasks {
+			fmt.Println(t)
+		}
+	},
+}

--- a/cli/cmd_gettasks.go
+++ b/cli/cmd_gettasks.go
@@ -21,7 +21,7 @@ var getTasksCmd = &cobra.Command{
 	Short: "gettasks",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		tasks, err := getTasks()
+		tasks, err := getBuildTasks()
 		errz.Log(err)
 
 		for _, t := range tasks {

--- a/cli/cmd_inspect.go
+++ b/cli/cmd_inspect.go
@@ -46,7 +46,7 @@ var envCmd = &cobra.Command{
 		runEnv(taskname)
 	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		tasks, err := getTasks()
+		tasks, err := getBuildTasks()
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}
@@ -83,7 +83,7 @@ var exportCmd = &cobra.Command{
 		runExport(taskname)
 	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		tasks, err := getTasks()
+		tasks, err := getBuildTasks()
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}
@@ -123,7 +123,7 @@ var inspectArtifactCmd = &cobra.Command{
 		runInspectArtifact(inspectArtifactId)
 	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		tasks, err := getTasks()
+		tasks, err := getBuildTasks()
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}

--- a/cli/cmd_run.go
+++ b/cli/cmd_run.go
@@ -31,7 +31,7 @@ var runCmd = &cobra.Command{
 		run(taskname, noCache)
 	},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		tasks, err := getRuns()
+		tasks, err := getRunTasks()
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}
@@ -82,14 +82,6 @@ func run(taskname string, noCache bool) {
 	if commander != nil {
 		<-commander.Done()
 	}
-}
-
-func getRuns() ([]string, error) {
-	b, err := bob.Bob()
-	if err != nil {
-		return nil, err
-	}
-	return b.GetRunTasks()
 }
 
 func getRunTasks() ([]string, error) {

--- a/cli/cmd_run.go
+++ b/cli/cmd_run.go
@@ -89,5 +89,13 @@ func getRuns() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return b.GetRunList()
+	return b.GetRunTasks()
+}
+
+func getRunTasks() ([]string, error) {
+	b, err := bob.Bob()
+	if err != nil {
+		return nil, err
+	}
+	return b.GetRunTasks()
 }

--- a/cli/cmd_run_list.go
+++ b/cli/cmd_run_list.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/benchkram/bob/bob"
 	"github.com/benchkram/bob/pkg/boblog"
 	"github.com/spf13/cobra"
@@ -19,6 +21,10 @@ func runRunList() {
 	b, err := bob.Bob()
 	boblog.Log.Error(err, "Unable to initialize bob")
 
-	err = b.RunList()
+	tasks, err := b.GetRunTasks()
 	boblog.Log.Error(err, "Unable to list tasks")
+
+	for _, t := range tasks {
+		fmt.Println(t)
+	}
 }


### PR DESCRIPTION
This PR adds `AggregateSparse()` and uses it to get the tasknames faster. Intended to be used for cli completion. It doesn't call sanitize and removes most intitalisation overhead which is only required if doing a build.

Before:  1,29sec
After:     250ms

Hint: The initial `find()` function is responsible for about >95% (240ms) of execution time  (see flamegraph) only for searching child bobfiles. In case we implement **imports** the dimension is ~10ms for a medium size project. Though ~1ms would be ideal as much bigger projects exist.. no master plan (yet) how to get there.

![image](https://user-images.githubusercontent.com/3776893/166069629-5f7af98a-a8d8-466a-8419-13eb79d97d42.png)
