### PR TITLE
cli speed improvements - imports

### DIFF
--- a/bob/aggregate.go
+++ b/bob/aggregate.go
@@ -60,7 +60,7 @@ func (b *B) AggregateSparse() (aggregate *bobfile.Bobfile, err error) {
 		return nil, usererror.Wrap(ErrCouldNotFindTopLevelBobfile)
 	}
 
-	bobs, err := readImports(aggregate)
+	bobs, err := readImports(aggregate, true)
 	errz.Fatal(err)
 
 	// set project names for all bobfiles and build tasks
@@ -91,7 +91,7 @@ func (b *B) Aggregate() (aggregate *bobfile.Bobfile, err error) {
 		return nil, usererror.Wrap(ErrCouldNotFindTopLevelBobfile)
 	}
 
-	bobs, err := readImports(aggregate)
+	bobs, err := readImports(aggregate, false)
 	errz.Fatal(err)
 
 	// FIXME: As we don't refer to a child task by projectname but by path

--- a/bob/aggregate.go
+++ b/bob/aggregate.go
@@ -80,7 +80,7 @@ func (b *B) Aggregate() (aggregate *bobfile.Bobfile, err error) {
 	defer errz.Recover(&err)
 
 	wd, _ := os.Getwd()
-	aggregate, err = bobfile.BobfileReadPlain(wd)
+	aggregate, err = bobfile.BobfileRead(wd)
 	errz.Fatal(err)
 
 	if !file.Exists(global.BobFileName) {
@@ -98,7 +98,7 @@ func (b *B) Aggregate() (aggregate *bobfile.Bobfile, err error) {
 	// it seems to be save to allow duplicate projectnames.
 	//projectNames := map[string]bool{}
 
-	for _, boblet := range bobs {
+	for _, boblet := range append(bobs, aggregate) {
 
 		// FIXME: As we don't refer to a child task by projectname but by path
 		// it seems to be save to allow duplicate projectnames.

--- a/bob/aggregate.go
+++ b/bob/aggregate.go
@@ -2,10 +2,12 @@ package bob
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/benchkram/bob/bobtask"
+	"github.com/benchkram/bob/pkg/file"
 	"github.com/benchkram/bob/pkg/usererror"
 
 	"github.com/logrusorgru/aurora"
@@ -13,29 +15,13 @@ import (
 	"github.com/benchkram/errz"
 
 	"github.com/benchkram/bob/bob/bobfile"
-	"github.com/benchkram/bob/pkg/filepathutil"
+	"github.com/benchkram/bob/bob/global"
 	"github.com/hashicorp/go-version"
 )
 
 var (
 	ErrDuplicateProjectName = fmt.Errorf("duplicate project name")
 )
-
-// find bobfiles recursively.
-func (b *B) find() (bobfiles []string, err error) {
-	defer errz.Recover(&err)
-
-	list, err := filepathutil.ListRecursive(b.dir)
-	errz.Fatal(err)
-
-	for _, file := range list {
-		if bobfile.IsBobfile(file) {
-			bobfiles = append(bobfiles, file)
-		}
-	}
-
-	return bobfiles, nil
-}
 
 func (b *B) PrintVersionCompatibility(bobfile *bobfile.Bobfile) {
 	binVersion, _ := version.NewVersion(Version)
@@ -62,24 +48,20 @@ func (b *B) PrintVersionCompatibility(bobfile *bobfile.Bobfile) {
 func (b *B) AggregateSparse() (aggregate *bobfile.Bobfile, err error) {
 	defer errz.Recover(&err)
 
-	bobfiles, err := b.find()
+	wd, _ := os.Getwd()
+	aggregate, err = bobfile.BobfileReadPlain(wd)
 	errz.Fatal(err)
-	bobs := []*bobfile.Bobfile{}
 
-	for _, bf := range bobfiles {
-		boblet, err := bobfile.BobfileReadPlain(filepath.Dir(bf))
-		errz.Fatal(err)
-
-		if boblet.Dir() == b.dir {
-			aggregate = boblet
-		}
-
-		bobs = append(bobs, boblet)
+	if !file.Exists(global.BobFileName) {
+		return nil, usererror.Wrap(ErrCouldNotFindTopLevelBobfile)
 	}
 
 	if aggregate == nil {
 		return nil, usererror.Wrap(ErrCouldNotFindTopLevelBobfile)
 	}
+
+	bobs, err := readImports(aggregate)
+	errz.Fatal(err)
 
 	// set project names for all bobfiles and build tasks
 	aggregate, bobs = syncProjectName(aggregate, bobs)
@@ -97,22 +79,26 @@ func (b *B) AggregateSparse() (aggregate *bobfile.Bobfile, err error) {
 func (b *B) Aggregate() (aggregate *bobfile.Bobfile, err error) {
 	defer errz.Recover(&err)
 
-	bobfiles, err := b.find()
+	wd, _ := os.Getwd()
+	aggregate, err = bobfile.BobfileReadPlain(wd)
+	errz.Fatal(err)
+
+	if !file.Exists(global.BobFileName) {
+		return nil, usererror.Wrap(ErrCouldNotFindTopLevelBobfile)
+	}
+
+	if aggregate == nil {
+		return nil, usererror.Wrap(ErrCouldNotFindTopLevelBobfile)
+	}
+
+	bobs, err := readImports(aggregate)
 	errz.Fatal(err)
 
 	// FIXME: As we don't refer to a child task by projectname but by path
 	// it seems to be save to allow duplicate projectnames.
 	//projectNames := map[string]bool{}
 
-	// Read & Find Bobfiles
-	bobs := []*bobfile.Bobfile{}
-	for _, bf := range bobfiles {
-		boblet, err := bobfile.BobfileRead(filepath.Dir(bf))
-		errz.Fatal(err)
-
-		if boblet.Dir() == b.dir {
-			aggregate = boblet
-		}
+	for _, boblet := range bobs {
 
 		// FIXME: As we don't refer to a child task by projectname but by path
 		// it seems to be save to allow duplicate projectnames.
@@ -135,13 +121,11 @@ func (b *B) Aggregate() (aggregate *bobfile.Bobfile, err error) {
 				boblet.BTasks[key] = task
 			}
 		}
-
-		bobs = append(bobs, boblet)
 	}
 
-	if aggregate == nil {
-		return nil, usererror.Wrap(ErrCouldNotFindTopLevelBobfile)
-	}
+	// FIXME: As we don't refer to a child task by projectname but by path
+	// it seems to be save to allow duplicate projectnames.
+	//projectNames := map[string]bool{}
 
 	if aggregate.Project == "" {
 		// TODO: maybe don't leak absolute path of environment

--- a/bob/aggregate_util.go
+++ b/bob/aggregate_util.go
@@ -1,9 +1,13 @@
 package bob
 
 import (
+	"errors"
+	"path/filepath"
 	"strings"
 
 	"github.com/benchkram/bob/bob/bobfile"
+	"github.com/benchkram/bob/pkg/usererror"
+	"github.com/benchkram/errz"
 )
 
 // syncProjectName project names for all bobfiles and build tasks
@@ -95,4 +99,40 @@ func (b *B) addRunTasksToAggregate(
 	}
 
 	return a
+}
+
+// readImports recursively
+//
+// If prefix is given it's appended to the search path to asuure
+// correctness of the search path in case of recursive calls.
+func readImports(
+	a *bobfile.Bobfile,
+	prefix ...string,
+) (imports []*bobfile.Bobfile, err error) {
+	errz.Recover(&err)
+
+	var p string
+	if len(prefix) > 0 {
+		p = prefix[0]
+	}
+
+	imports = []*bobfile.Bobfile{}
+	for _, imp := range a.Imports {
+		// read bobfile
+		boblet, err := bobfile.BobfileReadPlain(filepath.Join(p, imp))
+		if err != nil {
+			if errors.Is(err, bobfile.ErrBobfileNotFound) {
+				return nil, usererror.Wrap(err)
+			}
+			errz.Fatal(err)
+		}
+		imports = append(imports, boblet)
+
+		// read imports rescursively
+		childImports, err := readImports(boblet, boblet.Dir())
+		errz.Fatal(err)
+		imports = append(imports, childImports...)
+	}
+
+	return imports, nil
 }

--- a/bob/aggregate_util.go
+++ b/bob/aggregate_util.go
@@ -1,0 +1,98 @@
+package bob
+
+import (
+	"strings"
+
+	"github.com/benchkram/bob/bob/bobfile"
+)
+
+// syncProjectName project names for all bobfiles and build tasks
+func syncProjectName(
+	a *bobfile.Bobfile,
+	bobs []*bobfile.Bobfile,
+) (*bobfile.Bobfile, []*bobfile.Bobfile) {
+	for _, bobfile := range bobs {
+		bobfile.Project = a.Project
+
+		for taskname, task := range bobfile.BTasks {
+			// Should be the name of the umbrella-bobfile.
+			task.SetProject(a.Project)
+
+			// Overwrite value in build map
+			bobfile.BTasks[taskname] = task
+		}
+	}
+
+	return a, bobs
+}
+
+func (b *B) addBuildTasksToAggregate(
+	a *bobfile.Bobfile,
+	bobs []*bobfile.Bobfile,
+) *bobfile.Bobfile {
+
+	for _, bobfile := range bobs {
+		// Skip the aggregate
+		if bobfile.Dir() == a.Dir() {
+			continue
+		}
+
+		for taskname, task := range bobfile.BTasks {
+			dir := bobfile.Dir()
+
+			// Use a relative path as task prefix.
+			prefix := strings.TrimPrefix(dir, b.dir)
+			taskname := addTaskPrefix(prefix, taskname)
+
+			// Alter the taskname.
+			task.SetName(taskname)
+
+			// Rewrite dependent tasks to global scope.
+			dependsOn := []string{}
+			for _, dependentTask := range task.DependsOn {
+				dependsOn = append(dependsOn, addTaskPrefix(prefix, dependentTask))
+			}
+			task.DependsOn = dependsOn
+
+			a.BTasks[taskname] = task
+		}
+	}
+
+	return a
+}
+
+func (b *B) addRunTasksToAggregate(
+	a *bobfile.Bobfile,
+	bobs []*bobfile.Bobfile,
+) *bobfile.Bobfile {
+
+	for _, bobfile := range bobs {
+		// Skip the aggregate
+		if bobfile.Dir() == a.Dir() {
+			continue
+		}
+
+		for runname, run := range bobfile.RTasks {
+			dir := bobfile.Dir()
+
+			// Use a relative path as task prefix.
+			prefix := strings.TrimPrefix(dir, b.dir)
+
+			runname = addTaskPrefix(prefix, runname)
+
+			// Alter the runname.
+			run.SetName(runname)
+
+			// Rewrite dependents to global scope.
+			dependsOn := []string{}
+			for _, dependent := range run.DependsOn {
+				dependsOn = append(dependsOn, addTaskPrefix(prefix, dependent))
+			}
+			run.DependsOn = dependsOn
+
+			a.RTasks[runname] = run
+		}
+	}
+
+	return a
+}

--- a/bob/bobfile/bobfile.go
+++ b/bob/bobfile/bobfile.go
@@ -56,6 +56,8 @@ type Bobfile struct {
 	// of its bobfile.
 	Project string `yaml:"project,omitempty"`
 
+	Imports []string `yaml:"import,omitempty"`
+
 	Variables VariableMap
 
 	// BTasks build tasks
@@ -94,7 +96,7 @@ func bobfileRead(dir string) (_ *Bobfile, err error) {
 	bobfilePath := filepath.Join(dir, global.BobFileName)
 
 	if !file.Exists(bobfilePath) {
-		return nil, ErrBobfileNotFound
+		return nil, ErrBobfileNotFound //fmt.Errorf("%s contains no Bobfile, %w", dir, ErrBobfileNotFound)
 	}
 	bin, err := ioutil.ReadFile(bobfilePath)
 	errz.Fatal(err, "Failed to read config file")

--- a/bob/bobfile/bobfile.go
+++ b/bob/bobfile/bobfile.go
@@ -164,6 +164,20 @@ func BobfileRead(dir string) (_ *Bobfile, err error) {
 	return b, b.BTasks.Sanitize()
 }
 
+// BobfileReadPlain reads a bobfile.
+// For performance reasons sanitize is not called.
+func BobfileReadPlain(dir string) (_ *Bobfile, err error) {
+	defer errz.Recover(&err)
+
+	b, err := bobfileRead(dir)
+	errz.Fatal(err)
+
+	err = b.Validate()
+	errz.Fatal(err)
+
+	return b, nil
+}
+
 // Validate makes sure no task depends on itself (self-reference) or has the same name as another task
 func (b *Bobfile) Validate() (err error) {
 	if b.Version != "" {

--- a/bob/build_list.go
+++ b/bob/build_list.go
@@ -23,7 +23,7 @@ func (b *B) List() (err error) {
 func (b *B) GetList() (tasks []string, err error) {
 	defer errz.Recover(&err)
 
-	aggregate, err := b.Aggregate()
+	aggregate, err := b.AggregateSparse()
 	errz.Fatal(err)
 
 	keys := make([]string, 0, len(aggregate.BTasks))

--- a/bob/playground.go
+++ b/bob/playground.go
@@ -264,6 +264,11 @@ func createPlaygroundBobfile(dir string, overwrite bool, projectName string) (er
 
 	bobfile.Project = projectName
 
+	bobfile.Imports = []string{
+		"second-level",
+		"openapi-provider-project",
+	}
+
 	bobfile.Variables["helloworld"] = "Hello World!"
 
 	bobfile.BTasks[global.DefaultBuildTask] = bobtask.Task{
@@ -416,6 +421,8 @@ func createPlaygroundBobfileSecondLevel(dir string, overwrite bool, projectName 
 	bobfile := bobfile.NewBobfile()
 	bobfile.Version = "1.2.3"
 	bobfile.Project = projectName
+
+	bobfile.Imports = []string{"third-level"}
 
 	bobfile.BTasks[fmt.Sprintf("%s2", global.DefaultBuildTask)] = bobtask.Task{
 		InputDirty: "./main2.go",

--- a/cli/cmd_build.go
+++ b/cli/cmd_build.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"os/signal"
 	"strconv"
@@ -120,19 +119,4 @@ func getTasks() ([]string, error) {
 		return nil, err
 	}
 	return b.GetList()
-}
-
-// getTasksCmd cmd help to profile cli completion
-var getTasksCmd = &cobra.Command{
-	Use:   "gettasks",
-	Short: "gettasks",
-	Long:  ``,
-	Run: func(cmd *cobra.Command, args []string) {
-		tasks, err := getTasks()
-		errz.Log(err)
-
-		for _, t := range tasks {
-			fmt.Println(t)
-		}
-	},
 }

--- a/cli/cmd_build.go
+++ b/cli/cmd_build.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/signal"
 	"strconv"
@@ -119,4 +120,19 @@ func getTasks() ([]string, error) {
 		return nil, err
 	}
 	return b.GetList()
+}
+
+// getTasksCmd cmd help to profile cli completion
+var getTasksCmd = &cobra.Command{
+	Use:   "gettasks",
+	Short: "gettasks",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		tasks, err := getTasks()
+		errz.Log(err)
+
+		for _, t := range tasks {
+			fmt.Println(t)
+		}
+	},
 }

--- a/cli/cmd_gettasks.go
+++ b/cli/cmd_gettasks.go
@@ -4,10 +4,13 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 
-	"github.com/benchkram/errz"
+	"github.com/benchkram/bob/pkg/boblog"
+	"github.com/benchkram/bob/pkg/usererror"
 
+	"github.com/benchkram/errz"
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +25,11 @@ var getTasksCmd = &cobra.Command{
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		tasks, err := getTasks()
-		errz.Log(err)
+		if errors.As(err, &usererror.Err) {
+			boblog.Log.UserError(err)
+		} else {
+			errz.Fatal(err)
+		}
 
 		for _, t := range tasks {
 			fmt.Println(t)

--- a/cli/cmd_gettasks.go
+++ b/cli/cmd_gettasks.go
@@ -1,0 +1,31 @@
+//go:build dev
+// +build dev
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/benchkram/errz"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(getTasksCmd)
+}
+
+// getTasksCmd cmd help to profile cli completion
+var getTasksCmd = &cobra.Command{
+	Use:   "gettasks",
+	Short: "gettasks",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		tasks, err := getTasks()
+		errz.Log(err)
+
+		for _, t := range tasks {
+			fmt.Println(t)
+		}
+	},
+}


### PR DESCRIPTION
This PR adds a import statement to get rid of `find()`. It is a breaking change as child Bobfiles must now be declared instead of automatically resolved.

TODO: Create test for diamond imports => as @zuzuleinen pointed out.. this is not necessary.


Depended On https://github.com/benchkram/bob/pull/51

