### PR TITLE
cli speed improvements - parallel

### DIFF
--- a/bob/aggregate.go
+++ b/bob/aggregate.go
@@ -80,7 +80,7 @@ func (b *B) Aggregate() (aggregate *bobfile.Bobfile, err error) {
 	defer errz.Recover(&err)
 
 	wd, _ := os.Getwd()
-	aggregate, err = bobfile.BobfileReadPlain(wd)
+	aggregate, err = bobfile.BobfileRead(wd)
 	errz.Fatal(err)
 
 	if !file.Exists(global.BobFileName) {
@@ -98,7 +98,7 @@ func (b *B) Aggregate() (aggregate *bobfile.Bobfile, err error) {
 	// it seems to be save to allow duplicate projectnames.
 	//projectNames := map[string]bool{}
 
-	for _, boblet := range bobs {
+	for _, boblet := range append(bobs, aggregate) {
 
 		// FIXME: As we don't refer to a child task by projectname but by path
 		// it seems to be save to allow duplicate projectnames.

--- a/bob/aggregate.go
+++ b/bob/aggregate.go
@@ -2,10 +2,12 @@ package bob
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/benchkram/bob/bobtask"
+	"github.com/benchkram/bob/pkg/file"
 	"github.com/benchkram/bob/pkg/usererror"
 
 	"github.com/logrusorgru/aurora"
@@ -13,29 +15,13 @@ import (
 	"github.com/benchkram/errz"
 
 	"github.com/benchkram/bob/bob/bobfile"
-	"github.com/benchkram/bob/pkg/filepathutil"
+	"github.com/benchkram/bob/bob/global"
 	"github.com/hashicorp/go-version"
 )
 
 var (
 	ErrDuplicateProjectName = fmt.Errorf("duplicate project name")
 )
-
-// find bobfiles recursively.
-func (b *B) find() (bobfiles []string, err error) {
-	defer errz.Recover(&err)
-
-	list, err := filepathutil.ListRecursive(b.dir)
-	errz.Fatal(err)
-
-	for _, file := range list {
-		if bobfile.IsBobfile(file) {
-			bobfiles = append(bobfiles, file)
-		}
-	}
-
-	return bobfiles, nil
-}
 
 func (b *B) PrintVersionCompatibility(bobfile *bobfile.Bobfile) {
 	binVersion, _ := version.NewVersion(Version)
@@ -62,24 +48,20 @@ func (b *B) PrintVersionCompatibility(bobfile *bobfile.Bobfile) {
 func (b *B) AggregateSparse() (aggregate *bobfile.Bobfile, err error) {
 	defer errz.Recover(&err)
 
-	bobfiles, err := b.find()
+	wd, _ := os.Getwd()
+	aggregate, err = bobfile.BobfileReadPlain(wd)
 	errz.Fatal(err)
-	bobs := []*bobfile.Bobfile{}
 
-	for _, bf := range bobfiles {
-		boblet, err := bobfile.BobfileReadPlain(filepath.Dir(bf))
-		errz.Fatal(err)
-
-		if boblet.Dir() == b.dir {
-			aggregate = boblet
-		}
-
-		bobs = append(bobs, boblet)
+	if !file.Exists(global.BobFileName) {
+		return nil, usererror.Wrap(ErrCouldNotFindTopLevelBobfile)
 	}
 
 	if aggregate == nil {
 		return nil, usererror.Wrap(ErrCouldNotFindTopLevelBobfile)
 	}
+
+	bobs, err := readImports(aggregate)
+	errz.Fatal(err)
 
 	// set project names for all bobfiles and build tasks
 	aggregate, bobs = syncProjectName(aggregate, bobs)
@@ -97,22 +79,26 @@ func (b *B) AggregateSparse() (aggregate *bobfile.Bobfile, err error) {
 func (b *B) Aggregate() (aggregate *bobfile.Bobfile, err error) {
 	defer errz.Recover(&err)
 
-	bobfiles, err := b.find()
+	wd, _ := os.Getwd()
+	aggregate, err = bobfile.BobfileReadPlain(wd)
+	errz.Fatal(err)
+
+	if !file.Exists(global.BobFileName) {
+		return nil, usererror.Wrap(ErrCouldNotFindTopLevelBobfile)
+	}
+
+	if aggregate == nil {
+		return nil, usererror.Wrap(ErrCouldNotFindTopLevelBobfile)
+	}
+
+	bobs, err := readImports(aggregate)
 	errz.Fatal(err)
 
 	// FIXME: As we don't refer to a child task by projectname but by path
 	// it seems to be save to allow duplicate projectnames.
 	//projectNames := map[string]bool{}
 
-	// Read & Find Bobfiles
-	bobs := []*bobfile.Bobfile{}
-	for _, bf := range bobfiles {
-		boblet, err := bobfile.BobfileRead(filepath.Dir(bf))
-		errz.Fatal(err)
-
-		if boblet.Dir() == b.dir {
-			aggregate = boblet
-		}
+	for _, boblet := range bobs {
 
 		// FIXME: As we don't refer to a child task by projectname but by path
 		// it seems to be save to allow duplicate projectnames.
@@ -135,13 +121,11 @@ func (b *B) Aggregate() (aggregate *bobfile.Bobfile, err error) {
 				boblet.BTasks[key] = task
 			}
 		}
-
-		bobs = append(bobs, boblet)
 	}
 
-	if aggregate == nil {
-		return nil, usererror.Wrap(ErrCouldNotFindTopLevelBobfile)
-	}
+	// FIXME: As we don't refer to a child task by projectname but by path
+	// it seems to be save to allow duplicate projectnames.
+	//projectNames := map[string]bool{}
 
 	if aggregate.Project == "" {
 		// TODO: maybe don't leak absolute path of environment

--- a/bob/aggregate_util.go
+++ b/bob/aggregate_util.go
@@ -1,9 +1,13 @@
 package bob
 
 import (
+	"errors"
+	"path/filepath"
 	"strings"
 
 	"github.com/benchkram/bob/bob/bobfile"
+	"github.com/benchkram/bob/pkg/usererror"
+	"github.com/benchkram/errz"
 )
 
 // syncProjectName project names for all bobfiles and build tasks
@@ -95,4 +99,40 @@ func (b *B) addRunTasksToAggregate(
 	}
 
 	return a
+}
+
+// readImports recursively
+//
+// If prefix is given it's appended to the search path to asuure
+// correctness of the search path in case of recursive calls.
+func readImports(
+	a *bobfile.Bobfile,
+	prefix ...string,
+) (imports []*bobfile.Bobfile, err error) {
+	errz.Recover(&err)
+
+	var p string
+	if len(prefix) > 0 {
+		p = prefix[0]
+	}
+
+	imports = []*bobfile.Bobfile{}
+	for _, imp := range a.Imports {
+		// read bobfile
+		boblet, err := bobfile.BobfileReadPlain(filepath.Join(p, imp))
+		if err != nil {
+			if errors.Is(err, bobfile.ErrBobfileNotFound) {
+				return nil, usererror.Wrap(err)
+			}
+			errz.Fatal(err)
+		}
+		imports = append(imports, boblet)
+
+		// read imports rescursively
+		childImports, err := readImports(boblet, boblet.Dir())
+		errz.Fatal(err)
+		imports = append(imports, childImports...)
+	}
+
+	return imports, nil
 }

--- a/bob/aggregate_util.go
+++ b/bob/aggregate_util.go
@@ -1,0 +1,98 @@
+package bob
+
+import (
+	"strings"
+
+	"github.com/benchkram/bob/bob/bobfile"
+)
+
+// syncProjectName project names for all bobfiles and build tasks
+func syncProjectName(
+	a *bobfile.Bobfile,
+	bobs []*bobfile.Bobfile,
+) (*bobfile.Bobfile, []*bobfile.Bobfile) {
+	for _, bobfile := range bobs {
+		bobfile.Project = a.Project
+
+		for taskname, task := range bobfile.BTasks {
+			// Should be the name of the umbrella-bobfile.
+			task.SetProject(a.Project)
+
+			// Overwrite value in build map
+			bobfile.BTasks[taskname] = task
+		}
+	}
+
+	return a, bobs
+}
+
+func (b *B) addBuildTasksToAggregate(
+	a *bobfile.Bobfile,
+	bobs []*bobfile.Bobfile,
+) *bobfile.Bobfile {
+
+	for _, bobfile := range bobs {
+		// Skip the aggregate
+		if bobfile.Dir() == a.Dir() {
+			continue
+		}
+
+		for taskname, task := range bobfile.BTasks {
+			dir := bobfile.Dir()
+
+			// Use a relative path as task prefix.
+			prefix := strings.TrimPrefix(dir, b.dir)
+			taskname := addTaskPrefix(prefix, taskname)
+
+			// Alter the taskname.
+			task.SetName(taskname)
+
+			// Rewrite dependent tasks to global scope.
+			dependsOn := []string{}
+			for _, dependentTask := range task.DependsOn {
+				dependsOn = append(dependsOn, addTaskPrefix(prefix, dependentTask))
+			}
+			task.DependsOn = dependsOn
+
+			a.BTasks[taskname] = task
+		}
+	}
+
+	return a
+}
+
+func (b *B) addRunTasksToAggregate(
+	a *bobfile.Bobfile,
+	bobs []*bobfile.Bobfile,
+) *bobfile.Bobfile {
+
+	for _, bobfile := range bobs {
+		// Skip the aggregate
+		if bobfile.Dir() == a.Dir() {
+			continue
+		}
+
+		for runname, run := range bobfile.RTasks {
+			dir := bobfile.Dir()
+
+			// Use a relative path as task prefix.
+			prefix := strings.TrimPrefix(dir, b.dir)
+
+			runname = addTaskPrefix(prefix, runname)
+
+			// Alter the runname.
+			run.SetName(runname)
+
+			// Rewrite dependents to global scope.
+			dependsOn := []string{}
+			for _, dependent := range run.DependsOn {
+				dependsOn = append(dependsOn, addTaskPrefix(prefix, dependent))
+			}
+			run.DependsOn = dependsOn
+
+			a.RTasks[runname] = run
+		}
+	}
+
+	return a
+}

--- a/bob/bobfile/bobfile.go
+++ b/bob/bobfile/bobfile.go
@@ -56,6 +56,8 @@ type Bobfile struct {
 	// of its bobfile.
 	Project string `yaml:"project,omitempty"`
 
+	Imports []string `yaml:"import,omitempty"`
+
 	Variables VariableMap
 
 	// BTasks build tasks
@@ -94,7 +96,7 @@ func bobfileRead(dir string) (_ *Bobfile, err error) {
 	bobfilePath := filepath.Join(dir, global.BobFileName)
 
 	if !file.Exists(bobfilePath) {
-		return nil, ErrBobfileNotFound
+		return nil, ErrBobfileNotFound //fmt.Errorf("%s contains no Bobfile, %w", dir, ErrBobfileNotFound)
 	}
 	bin, err := ioutil.ReadFile(bobfilePath)
 	errz.Fatal(err, "Failed to read config file")

--- a/bob/bobfile/bobfile.go
+++ b/bob/bobfile/bobfile.go
@@ -164,6 +164,20 @@ func BobfileRead(dir string) (_ *Bobfile, err error) {
 	return b, b.BTasks.Sanitize()
 }
 
+// BobfileReadPlain reads a bobfile.
+// For performance reasons sanitize is not called.
+func BobfileReadPlain(dir string) (_ *Bobfile, err error) {
+	defer errz.Recover(&err)
+
+	b, err := bobfileRead(dir)
+	errz.Fatal(err)
+
+	err = b.Validate()
+	errz.Fatal(err)
+
+	return b, nil
+}
+
 // Validate makes sure no task depends on itself (self-reference) or has the same name as another task
 func (b *Bobfile) Validate() (err error) {
 	if b.Version != "" {

--- a/bob/build.go
+++ b/bob/build.go
@@ -27,6 +27,9 @@ func (b *B) Build(ctx context.Context, taskname string) (err error) {
 	)
 	errz.Fatal(err)
 
+	err = playbook.PreComputeInputHashes()
+	errz.Fatal(err)
+
 	err = playbook.Build(ctx)
 	errz.Fatal(err)
 

--- a/bob/build_list.go
+++ b/bob/build_list.go
@@ -23,7 +23,7 @@ func (b *B) List() (err error) {
 func (b *B) GetList() (tasks []string, err error) {
 	defer errz.Recover(&err)
 
-	aggregate, err := b.Aggregate()
+	aggregate, err := b.AggregateSparse()
 	errz.Fatal(err)
 
 	keys := make([]string, 0, len(aggregate.BTasks))

--- a/bob/playbook/hash.go
+++ b/bob/playbook/hash.go
@@ -1,0 +1,28 @@
+package playbook
+
+import (
+	"github.com/benchkram/errz"
+)
+
+// PreComputeInputHashes asynchronically
+func (pb *Playbook) PreComputeInputHashes() error {
+
+	// 3 parallel goroutines was the fastest one
+	// on a test project.
+	const max = 3
+
+	sem := make(chan int, max)
+	for _, t := range pb.Tasks {
+		sem <- 1
+
+		// input hash
+		go func() {
+			_, err := t.HashIn()
+			errz.Log(err)
+			<-sem
+		}()
+
+	}
+
+	return nil
+}

--- a/bob/playground.go
+++ b/bob/playground.go
@@ -264,6 +264,11 @@ func createPlaygroundBobfile(dir string, overwrite bool, projectName string) (er
 
 	bobfile.Project = projectName
 
+	bobfile.Imports = []string{
+		"second-level",
+		"openapi-provider-project",
+	}
+
 	bobfile.Variables["helloworld"] = "Hello World!"
 
 	bobfile.BTasks[global.DefaultBuildTask] = bobtask.Task{
@@ -416,6 +421,8 @@ func createPlaygroundBobfileSecondLevel(dir string, overwrite bool, projectName 
 	bobfile := bobfile.NewBobfile()
 	bobfile.Version = "1.2.3"
 	bobfile.Project = projectName
+
+	bobfile.Imports = []string{"third-level"}
 
 	bobfile.BTasks[fmt.Sprintf("%s2", global.DefaultBuildTask)] = bobtask.Task{
 		InputDirty: "./main2.go",

--- a/bobtask/hash_in.go
+++ b/bobtask/hash_in.go
@@ -8,53 +8,32 @@ import (
 	"os"
 	"sort"
 	"strings"
-	"sync"
 
 	"github.com/benchkram/bob/bobtask/hash"
 	"github.com/benchkram/bob/pkg/filehash"
 	"gopkg.in/yaml.v2"
 )
 
-var hashCacheMutex = sync.Mutex{}
-var hashCache = make(map[string][]byte, 10000)
-
 // HashIn computes a hash containing inputs, environment and the task description.
-func (t *Task) HashIn() (taskHash hash.In, _ error) {
+func (t *Task) HashIn() (taskHash hash.In, err error) {
 	if t.hashIn != nil {
 		return *t.hashIn, nil
 	}
 
-	aggregatedHashes := bytes.NewBuffer([]byte{})
+	h := filehash.New()
 
 	// Hash input files
 	for _, f := range t.inputs {
-		var h []byte
-		hashCacheMutex.Lock()
-		hash, ok := hashCache[f]
-		hashCacheMutex.Unlock()
-		if ok {
-			// reuse hash
-			h = hash
-		} else {
-			// recompute hash
-			var errr error
-			h, errr = filehash.Hash(f)
-			if errr != nil {
-				if errors.Is(errr, os.ErrPermission) {
-					t.addToSkippedInputs(f)
-					continue
-				} else {
-					return taskHash, fmt.Errorf("failed to hash file %q: %w", f, errr)
-				}
-			}
-			hashCacheMutex.Lock()
-			hashCache[f] = h
-			hashCacheMutex.Unlock()
-		}
 
-		_, err := aggregatedHashes.Write(h)
+		// compute file hash
+		err = h.AddFile(f)
 		if err != nil {
-			return taskHash, fmt.Errorf("failed to write file hash to aggregated hash %q: %w", f, err)
+			if errors.Is(err, os.ErrPermission) {
+				t.addToSkippedInputs(f)
+				continue
+			} else {
+				return taskHash, fmt.Errorf("failed to hash file %q: %w", f, err)
+			}
 		}
 	}
 
@@ -63,44 +42,32 @@ func (t *Task) HashIn() (taskHash hash.In, _ error) {
 	if err != nil {
 		return taskHash, fmt.Errorf("failed to marshal task: %w", err)
 	}
-	descriptionHash, err := filehash.HashBytes(bytes.NewBuffer(description))
+	err = h.AddBytes(bytes.NewBuffer(description))
 	if err != nil {
 		return taskHash, fmt.Errorf("failed to write description hash: %w", err)
 	}
-	_, err = aggregatedHashes.Write(descriptionHash)
-	if err != nil {
-		return taskHash, fmt.Errorf("failed to write task description to aggregated hash: %w", err)
-	}
 
 	// Hash the project name
-	projectNameHash, err := filehash.HashBytes(bytes.NewBuffer([]byte(t.project)))
+	err = h.AddBytes(bytes.NewBuffer([]byte(t.project)))
 	if err != nil {
 		return taskHash, fmt.Errorf("failed to write project name hash: %w", err)
-	}
-	_, err = aggregatedHashes.Write(projectNameHash)
-	if err != nil {
-		return taskHash, fmt.Errorf("failed to write task description to aggregated hash: %w", err)
 	}
 
 	// Hash the environment
 	sort.Strings(t.env)
 	environment := strings.Join(t.env, ",")
-	environmentHash, err := filehash.HashBytes(bytes.NewBufferString(environment))
+	err = h.AddBytes(bytes.NewBufferString(environment))
 	if err != nil {
-		return taskHash, fmt.Errorf("failed to write description hash: %w", err)
-	}
-	_, err = aggregatedHashes.Write(environmentHash)
-	if err != nil {
-		return taskHash, fmt.Errorf("failed to write task environment to aggregated hash: %w", err)
+		return taskHash, fmt.Errorf("failed to write environment hash: %w", err)
 	}
 
 	// Summarize
-	h, err := filehash.HashBytes(aggregatedHashes)
-	if err != nil {
-		return taskHash, fmt.Errorf("failed to write aggregated hash: %w", err)
-	}
+	// h, err := filehash.HashBytes(aggregatedHashes)
+	// if err != nil {
+	// 	return taskHash, fmt.Errorf("failed to write aggregated hash: %w", err)
+	// }
 
-	hashIn := hash.In(hex.EncodeToString(h))
+	hashIn := hash.In(hex.EncodeToString(h.Sum()))
 
 	// store hash for reuse
 	t.hashIn = &hashIn

--- a/bobtask/input.go
+++ b/bobtask/input.go
@@ -19,11 +19,12 @@ func (t *Task) Inputs() []string {
 // Calls sanitize on the result.
 func (t *Task) filteredInputs() ([]string, error) {
 
+	wd := t.dir
 	owd, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current working directory: %w", err)
 	}
-	if err := os.Chdir(t.dir); err != nil {
+	if err := os.Chdir(wd); err != nil {
 		return nil, fmt.Errorf("failed to change current working directory to %s: %w", t.dir, err)
 	}
 	defer func() {
@@ -84,7 +85,10 @@ func (t *Task) filteredInputs() ([]string, error) {
 		}
 	}
 
-	sanitizedInputs, err := t.sanitizeInputs(filteredInputs)
+	sanitizedInputs, err := t.sanitizeInputs(
+		filteredInputs,
+		optimisationOptions{wd: wd},
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sanitize inputs: %w", err)
 	}

--- a/bobtask/target.go
+++ b/bobtask/target.go
@@ -46,6 +46,9 @@ func (t *Task) Target() (empty target.Target, _ error) {
 // and has not been there before the task ran.
 func (t *Task) Clean() error {
 	if t.target != nil {
+
+		t.target.HashInvalidate()
+
 		for _, f := range t.target.Paths {
 			if t.dir == "" {
 				return fmt.Errorf("task dir not set")
@@ -62,6 +65,7 @@ func (t *Task) Clean() error {
 				return err
 			}
 			//fmt.Printf("%s\n", aurora.Green("done"))
+
 		}
 	}
 

--- a/bobtask/target/target.go
+++ b/bobtask/target/target.go
@@ -8,6 +8,7 @@ import (
 
 type Target interface {
 	Hash() (string, error)
+	HashInvalidate()
 	Verify() bool
 	Exists() bool
 
@@ -19,8 +20,11 @@ type T struct {
 	// working dir of target
 	dir string
 
-	// last computed hash of target
-	hash string
+	// hashFromBuildInfo is the last computed hash of target
+	hashFromBuildInfo string
+
+	// hashBeforeBuild is the hash of the target before a build started.
+	hashBeforeBuild string
 
 	// dockerRegistryClient utility functions to handle requests with local docker registry
 	dockerRegistryClient dockermobyutil.RegistryClient
@@ -73,7 +77,7 @@ func (t *T) WithDir(dir string) Target {
 }
 func (t *T) WithHash(hash string) Target {
 	target := t.clone()
-	target.hash = hash
+	target.hashFromBuildInfo = hash
 	return target
 }
 

--- a/bobtask/target/verify.go
+++ b/bobtask/target/verify.go
@@ -9,11 +9,11 @@ import (
 func (t *T) Verify() bool {
 	switch t.Type {
 	case Path:
-		return t.verifyFile(t.hash)
+		return t.verifyFile(t.hashFromBuildInfo)
 	case Docker:
-		return t.verifyDocker(t.hash)
+		return t.verifyDocker(t.hashFromBuildInfo)
 	default:
-		return t.verifyFile(t.hash)
+		return t.verifyFile(t.hashFromBuildInfo)
 	}
 }
 
@@ -22,7 +22,7 @@ func (t *T) verifyFile(groundTruth string) bool {
 		return true
 	}
 
-	if t.hash == "" {
+	if t.hashFromBuildInfo == "" {
 		return true
 	}
 
@@ -47,7 +47,7 @@ func (t *T) verifyDocker(groundTruth string) bool {
 		return true
 	}
 
-	if t.hash == "" {
+	if t.hashFromBuildInfo == "" {
 		return true
 	}
 

--- a/cli/cmd_build.go
+++ b/cli/cmd_build.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"os/signal"
 	"strconv"
@@ -120,19 +119,4 @@ func getTasks() ([]string, error) {
 		return nil, err
 	}
 	return b.GetList()
-}
-
-// getTasksCmd cmd help to profile cli completion
-var getTasksCmd = &cobra.Command{
-	Use:   "gettasks",
-	Short: "gettasks",
-	Long:  ``,
-	Run: func(cmd *cobra.Command, args []string) {
-		tasks, err := getTasks()
-		errz.Log(err)
-
-		for _, t := range tasks {
-			fmt.Println(t)
-		}
-	},
 }

--- a/cli/cmd_build.go
+++ b/cli/cmd_build.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/signal"
 	"strconv"
@@ -119,4 +120,19 @@ func getTasks() ([]string, error) {
 		return nil, err
 	}
 	return b.GetList()
+}
+
+// getTasksCmd cmd help to profile cli completion
+var getTasksCmd = &cobra.Command{
+	Use:   "gettasks",
+	Short: "gettasks",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		tasks, err := getTasks()
+		errz.Log(err)
+
+		for _, t := range tasks {
+			fmt.Println(t)
+		}
+	},
 }

--- a/cli/cmd_gettasks.go
+++ b/cli/cmd_gettasks.go
@@ -4,10 +4,13 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 
-	"github.com/benchkram/errz"
+	"github.com/benchkram/bob/pkg/boblog"
+	"github.com/benchkram/bob/pkg/usererror"
 
+	"github.com/benchkram/errz"
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +25,11 @@ var getTasksCmd = &cobra.Command{
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		tasks, err := getTasks()
-		errz.Log(err)
+		if errors.As(err, &usererror.Err) {
+			boblog.Log.UserError(err)
+		} else {
+			errz.Fatal(err)
+		}
 
 		for _, t := range tasks {
 			fmt.Println(t)

--- a/cli/cmd_gettasks.go
+++ b/cli/cmd_gettasks.go
@@ -1,0 +1,31 @@
+//go:build dev
+// +build dev
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/benchkram/errz"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(getTasksCmd)
+}
+
+// getTasksCmd cmd help to profile cli completion
+var getTasksCmd = &cobra.Command{
+	Use:   "gettasks",
+	Short: "gettasks",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		tasks, err := getTasks()
+		errz.Log(err)
+
+		for _, t := range tasks {
+			fmt.Println(t)
+		}
+	},
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/benchkram/errz v0.0.0-20180520163740-571a80a661f2
+	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/charmbracelet/bubbles v0.9.0
 	github.com/charmbracelet/bubbletea v0.19.1
 	github.com/charmbracelet/lipgloss v0.3.0

--- a/pkg/filehash/filehash.go
+++ b/pkg/filehash/filehash.go
@@ -1,0 +1,41 @@
+package filehash
+
+import (
+	"fmt"
+	"hash"
+	"io"
+	"os"
+)
+
+type H struct {
+	hash   hash.Hash
+	buffer []byte
+}
+
+func New() *H {
+	return &H{
+		hash:   hashFunc(),
+		buffer: make([]byte, 32*1024),
+	}
+}
+
+func (h *H) AddFile(file string) error {
+	f, err := os.Open(file)
+	if err != nil {
+		return fmt.Errorf("failed to open: %w", err)
+	}
+	defer f.Close()
+
+	return h.AddBytes(f)
+}
+
+func (h *H) AddBytes(r io.Reader) error {
+	if _, err := io.CopyBuffer(h.hash, r, h.buffer); err != nil {
+		return fmt.Errorf("failed to copy: %w", err)
+	}
+	return nil
+}
+
+func (h *H) Sum() []byte {
+	return h.hash.Sum(nil)
+}

--- a/pkg/filehash/hash.go
+++ b/pkg/filehash/hash.go
@@ -1,16 +1,15 @@
 package filehash
 
 import (
-	"crypto/sha1"
 	"fmt"
 	"io"
 	"os"
+
+	"github.com/cespare/xxhash"
 )
 
 var (
-	// Using sha1 shouldn't be a problem as hash collisions are very unlikely.
-	// sha1 is about twice as fast as sha256 on my — Leon's — machine.
-	hashFunc = sha1.New
+	hashFunc = xxhash.New
 )
 
 func Hash(file string) ([]byte, error) {

--- a/pkg/filehash/hash.go
+++ b/pkg/filehash/hash.go
@@ -19,7 +19,7 @@ func Hash(file string) ([]byte, error) {
 	}
 	defer f.Close()
 
-	return HashBytes(io.Reader(f))
+	return HashBytes(f)
 }
 
 func HashBytes(r io.Reader) ([]byte, error) {

--- a/pkg/filepathutil/list.go
+++ b/pkg/filepathutil/list.go
@@ -17,7 +17,14 @@ var (
 	}
 )
 
+var listRecursiveMap = make(map[string][]string, 1024)
+
 func ListRecursive(inp string) (all []string, err error) {
+
+	result, ok := listRecursiveMap[inp]
+	if ok {
+		return result, nil
+	}
 
 	// TODO: possibly ignore here too, before calling listDir
 	if s, err := os.Stat(inp); err != nil || !s.IsDir() {
@@ -56,13 +63,13 @@ func ListRecursive(inp string) (all []string, err error) {
 		all = append(all, files...)
 	}
 
+	listRecursiveMap[inp] = all
 	return all, nil
 }
 
 var WalkedDirs = map[string]int{}
 
 func listDir(path string) ([]string, error) {
-
 	times := WalkedDirs[path]
 	WalkedDirs[path] = times + 1
 


### PR DESCRIPTION
This PR adds 
* parallel process rampup (computing inpput hashes in parallel)
* reuse of already hashed files (broken: flaky/unexpected rebuilds)
* Check if https://github.com/benchkram/bob/blob/main/bobtask/sanitize.go#L74 affects parallel execution

TODO: Check&Fix the commits. They seem to contain content of other PR's