### PR TITLE
Docker compose shutdown before startup

### DIFF
--- a/bobrun/compose.go
+++ b/bobrun/compose.go
@@ -3,7 +3,6 @@ package bobrun
 import (
 	"context"
 	"fmt"
-
 	"github.com/benchkram/bob/pkg/composectl"
 	"github.com/benchkram/bob/pkg/composeutil"
 	"github.com/benchkram/bob/pkg/ctl"
@@ -16,6 +15,8 @@ const composeFileDefault = "docker-compose.yml"
 func (r *Run) composeCommand(ctx context.Context) (_ ctl.Command, err error) {
 	defer errz.Recover(&err)
 
+	fmt.Println("compose cmd")
+
 	path := r.Path
 	if path == "" {
 		path = composeFileDefault
@@ -24,44 +25,176 @@ func (r *Run) composeCommand(ctx context.Context) (_ ctl.Command, err error) {
 	p, err := composeutil.ProjectFromConfig(path)
 	errz.Fatal(err)
 
-	cfgs := composeutil.ProjectPortConfigs(p)
+	//// In case the environment was already running (because of crash during shutdown, for example), shut it down.
+	//ctler, err := composectl.New(p, "", "")
+	//errz.Fatal(err)
+	//
+	//err = ctler.Down(ctx)
+	//errz.Fatal(err)
 
-	portConflicts := ""
-	portMapping := ""
-	if composeutil.HasPortConflicts(cfgs) {
-		conflicts := composeutil.PortConflicts(cfgs)
+	//cfgs := composeutil.ProjectPortConfigs(p)
 
-		portConflicts = conflicts.String()
+	//portConflicts := ""
+	//portMapping := ""
+	//var resolved composeutil.PortConfigs
+	//
+	//if composeutil.HasPortConflicts(cfgs) {
+	//	conflicts := composeutil.PortConflicts(cfgs)
+	//
+	//	portConflicts = conflicts.String()
+	//
+	//	// TODO: disable once we also resolve binaries' ports
+	//	//errz.Fatal(usererror.Wrap(fmt.Errorf(fmt.Sprint("conflicting ports detected:\n", conflicts))))
+	//
+	//	resolved, err = composeutil.ResolvePortConflicts(conflicts)
+	//	errz.Fatal(err)
+	//
+	//	portMapping = resolved.String()
+	//
+	//	// update project's ports
+	//}
 
-		// TODO: disable once we also resolve binaries' ports
-		errz.Fatal(usererror.Wrap(fmt.Errorf(fmt.Sprint("conflicting ports detected:\n", conflicts))))
+	//ctler, err := composectl.New()
+	//errz.Fatal(err)
+	//
+	//err = ctler.Down(ctx, p)
+	//errz.Fatal(err)
+	//
+	//portConflicts = ""
+	//portMapping = ""
+	//if composeutil.HasPortConflicts(cfgs) {
+	//	conflicts := composeutil.PortConflicts(cfgs)
+	//
+	//	portConflicts = conflicts.String()
+	//
+	//	// TODO: disable once we also resolve binaries' ports
+	//	errz.Fatal(usererror.Wrap(fmt.Errorf(fmt.Sprint("conflicting ports detected:\n", conflicts))))
+	//
+	//	resolved, err := composeutil.ResolvePortConflicts(conflicts)
+	//	errz.Fatal(err)
+	//
+	//	portMapping = resolved.String()
+	//
+	//	// update project's ports
+	//	composeutil.ApplyPortMapping(p, resolved)
+	//}
+	//
+	//w := ctler.StdoutWriter()
+	//
+	//if portConflicts != "" {
+	//	portConflicts = fmt.Sprintf("%s\n%s\n", "Conflicting ports detected:", portConflicts)
+	//	_, err = w.Write([]byte(portConflicts))
+	//	if err != nil {
+	//		return nil, err
+	//	}
+	//}
+	//
+	//if portMapping != "" {
+	//	portMapping = fmt.Sprintf("%s\n%s\n", "Resolved port mapping:", portMapping)
+	//	_, err = w.Write([]byte(portMapping))
+	//	if err != nil {
+	//		return nil, err
+	//	}
+	//}
+	//
+	//rc := ctl.New(r.name, 1, ctler.Stdout(), ctler.Stderr(), ctler.Stdin())
+	//
+	//go func() {
+	//}()
 
-		resolved, err := composeutil.ResolvePortConflicts(conflicts)
-		errz.Fatal(err)
-
-		portMapping = resolved.String()
-
-		// update project's ports
-		composeutil.ApplyPortMapping(p, resolved)
-	}
-
-	ctler, err := composectl.New(p, portConflicts, portMapping)
+	ctler, err := composectl.New()
 	errz.Fatal(err)
 
+	w := ctler.StdoutWriter()
+
+	ready := make(chan bool)
+
+	go func() {
+		err = ctler.Down(ctx, p)
+		errz.Fatal(err)
+
+		cfgs := composeutil.ProjectPortConfigs(p)
+
+		portConflicts := ""
+		portMapping := ""
+		if composeutil.HasPortConflicts(cfgs) {
+			conflicts := composeutil.PortConflicts(cfgs)
+
+			portConflicts = conflicts.String()
+
+			// TODO: disable once we also resolve binaries' ports
+			errz.Fatal(usererror.Wrap(fmt.Errorf(fmt.Sprint("conflicting ports detected:\n", conflicts))))
+
+			resolved, err := composeutil.ResolvePortConflicts(conflicts)
+			errz.Fatal(err)
+
+			portMapping = resolved.String()
+
+			// update project's ports
+			composeutil.ApplyPortMapping(p, resolved)
+		}
+
+		if portConflicts != "" {
+			portConflicts = fmt.Sprintf("%s\n%s\n", "Conflicting ports detected:", portConflicts)
+			_, err = w.Write([]byte(portConflicts))
+			if err != nil {
+				errz.Fatal(err)
+			}
+		}
+
+		if portMapping != "" {
+			portMapping = fmt.Sprintf("%s\n%s\n", "Resolved port mapping:", portMapping)
+			_, err = w.Write([]byte(portMapping))
+			if err != nil {
+				errz.Fatal(err)
+			}
+		}
+
+		ready <- true
+	}()
+
+	//cfgs := composeutil.ProjectPortConfigs(p)
+
+	//if composeutil.HasPortConflicts(cfgs) {
+	//	conflicts := composeutil.PortConflicts(cfgs)
+	//
+	//	//portConflicts = conflicts.String()
+	//
+	//	// TODO: disable once we also resolve binaries' ports
+	//	//errz.Fatal(usererror.Wrap(fmt.Errorf(fmt.Sprint("conflicting ports detected:\n", conflicts))))
+	//
+	//	resolved, err := composeutil.ResolvePortConflicts(conflicts)
+	//	errz.Fatal(err)
+	//
+	//	//portMapping = resolved.String()
+	//
+	//	// update project's ports
+	//	composeutil.ApplyPortMapping(p, resolved)
+	//}
+
+	//w := ctler.StdoutWriter()
+
 	rc := ctl.New(r.name, 1, ctler.Stdout(), ctler.Stderr(), ctler.Stdin())
+
+	waitForReady := true
 
 	go func() {
 		for {
 			switch <-rc.Control() {
 			case ctl.Start:
-				err = ctler.Up(ctx)
+				if waitForReady {
+					<-ready
+					waitForReady = false
+				}
+
+				err = ctler.Up(ctx, p)
 				if err != nil {
 					rc.EmitError(err)
 				} else {
 					rc.EmitStarted()
 				}
 			case ctl.Stop:
-				err = ctler.Down(ctx)
+				err = ctler.Down(ctx, p)
 				if err != nil {
 					rc.EmitError(err)
 				} else {
@@ -70,7 +203,7 @@ func (r *Run) composeCommand(ctx context.Context) (_ ctl.Command, err error) {
 			case ctl.Shutdown:
 				// SIGINT takes an extra context to allow
 				// a cleanup.
-				_ = ctler.Down(ctx)
+				_ = ctler.Down(ctx, p)
 				// TODO: log error to a logger ot emit
 				rc.EmitDone()
 				return

--- a/cli/cmd_compose.go
+++ b/cli/cmd_compose.go
@@ -66,20 +66,20 @@ var composeCmd = &cobra.Command{
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			ctl, err := composectl.New(p, portConflicts, portMapping)
+			ctl, err := composectl.New()
 			if err != nil {
 				errz.Fatal(err)
 			}
 
 			fmt.Println()
-			err = ctl.Up(ctx)
+			err = ctl.Up(ctx, p)
 			if err != nil {
 				errz.Fatal(err)
 			}
 
 			defer func() {
 				fmt.Print("\n\n")
-				err := ctl.Down(context.Background())
+				err := ctl.Down(context.Background(), p)
 				if err != nil {
 					errz.Log(err)
 				}


### PR DESCRIPTION
This addresses bob run tasks failing if there are still some running containers on the user's environment.
Originally the user needed to stop+rm all running containers that had port conflicts *manually*. This PR automates this.