### PR TITLE
task: invalid task name is a user error

### DIFF
--- a/bob/aggregate.go
+++ b/bob/aggregate.go
@@ -172,7 +172,7 @@ func (b *B) Aggregate() (aggregate *bobfile.Bobfile, err error) {
 
 			dependentTask, ok := aggregate.BTasks[dependentTaskName]
 			if !ok {
-				return nil, boberror.ErrTaskDoesNotExistF(dependentTaskName)
+				return nil, usererror.Wrap(boberror.ErrTaskDoesNotExistF(dependentTaskName))
 			}
 
 			for exportname, export := range dependentTask.Exports {

--- a/bob/aggregate.go
+++ b/bob/aggregate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/benchkram/bob/bob/bobfile"
 	"github.com/benchkram/bob/bob/global"
 	"github.com/benchkram/bob/bobtask"
+	"github.com/benchkram/bob/pkg/boberror"
 	"github.com/benchkram/bob/pkg/file"
 	"github.com/benchkram/bob/pkg/usererror"
 
@@ -171,7 +172,7 @@ func (b *B) Aggregate() (aggregate *bobfile.Bobfile, err error) {
 
 			dependentTask, ok := aggregate.BTasks[dependentTaskName]
 			if !ok {
-				return nil, ErrTaskDoesNotExist
+				return nil, boberror.ErrTaskDoesNotExistF(dependentTaskName)
 			}
 
 			for exportname, export := range dependentTask.Exports {

--- a/bob/bobfile/bobfile.go
+++ b/bob/bobfile/bobfile.go
@@ -39,7 +39,6 @@ var (
 	ErrHashesFileDoesNotExist = fmt.Errorf("Hashes file does not exist")
 	ErrTaskHashDoesNotExist   = fmt.Errorf("Task hash does not exist")
 	ErrBobfileExists          = fmt.Errorf("Bobfile exists")
-	ErrTaskDoesNotExist       = fmt.Errorf("Task does not exist")
 	ErrDuplicateTaskName      = fmt.Errorf("duplicate task name")
 	ErrInvalidProjectName     = fmt.Errorf("invalid project name")
 	ErrSelfReference          = fmt.Errorf("self reference")

--- a/bob/build_nix.go
+++ b/bob/build_nix.go
@@ -2,6 +2,7 @@ package bob
 
 import (
 	"fmt"
+
 	"github.com/benchkram/bob/bob/bobfile"
 	"github.com/benchkram/bob/pkg/nix"
 	"github.com/benchkram/bob/pkg/usererror"

--- a/bob/error.go
+++ b/bob/error.go
@@ -5,7 +5,6 @@ import "fmt"
 var (
 	ErrConfigFileDoesNotExist      = fmt.Errorf("config file does not exist")
 	ErrRepoAlreadyAdded            = fmt.Errorf("repo already added")
-	ErrTaskDoesNotExist            = fmt.Errorf("task does not exist")
 	ErrRunDoesNotExist             = fmt.Errorf("run does not exist")
 	ErrWorkspaceAlreadyInitialised = fmt.Errorf("bob Workspace Already Initialized")
 	ErrTargetValidationFailed      = fmt.Errorf("target validation failed")

--- a/bob/playbook/playbook.go
+++ b/bob/playbook/playbook.go
@@ -13,6 +13,7 @@ import (
 	"github.com/benchkram/bob/pkg/boberror"
 	"github.com/benchkram/bob/pkg/boblog"
 	"github.com/benchkram/bob/pkg/buildinfostore"
+	"github.com/benchkram/bob/pkg/usererror"
 	"github.com/benchkram/errz"
 	"github.com/logrusorgru/aurora"
 )
@@ -88,7 +89,7 @@ const (
 func (p *Playbook) TaskNeedsRebuild(taskname string, hashIn hash.In) (rebuildRequired bool, cause RebuildCause, err error) {
 	ts, ok := p.Tasks[taskname]
 	if !ok {
-		return false, "", boberror.ErrTaskDoesNotExistF(taskname)
+		return false, "", usererror.Wrap(boberror.ErrTaskDoesNotExistF(taskname))
 	}
 	task := ts.Task
 	coloredName := task.ColoredName()
@@ -208,7 +209,7 @@ func (p *Playbook) play() error {
 				t, ok := p.Tasks[dependentTaskName]
 				if !ok {
 					//fmt.Printf("Task %s does not exist", dependentTaskName)
-					return boberror.ErrTaskDoesNotExistF(dependentTaskName)
+					return usererror.Wrap(boberror.ErrTaskDoesNotExistF(dependentTaskName))
 				}
 				// fmt.Printf("dependentTask %s which is in state %s\n", t.Task.Name(), t.State())
 
@@ -293,7 +294,7 @@ func (p *Playbook) setTaskState(taskname string, state State, taskError error) e
 func (p *Playbook) pack(taskname string, hash hash.In) error {
 	task, ok := p.Tasks[taskname]
 	if !ok {
-		return boberror.ErrTaskDoesNotExistF(taskname)
+		return usererror.Wrap(boberror.ErrTaskDoesNotExistF(taskname))
 	}
 	return task.Task.ArtifactPack(hash)
 }
@@ -301,7 +302,7 @@ func (p *Playbook) pack(taskname string, hash hash.In) error {
 func (p *Playbook) storeHash(taskname string, buildinfo *buildinfo.I) error {
 	task, ok := p.Tasks[taskname]
 	if !ok {
-		return boberror.ErrTaskDoesNotExistF(taskname)
+		return usererror.Wrap(boberror.ErrTaskDoesNotExistF(taskname))
 	}
 
 	return task.Task.WriteBuildinfo(buildinfo)
@@ -315,7 +316,7 @@ func (p *Playbook) ExecutionTime() time.Duration {
 func (p *Playbook) TaskStatus(taskname string) (ts *Status, _ error) {
 	status, ok := p.Tasks[taskname]
 	if !ok {
-		return ts, boberror.ErrTaskDoesNotExistF(taskname)
+		return ts, usererror.Wrap(boberror.ErrTaskDoesNotExistF(taskname))
 	}
 	return status, nil
 }
@@ -326,7 +327,7 @@ func (p *Playbook) TaskCompleted(taskname string) (err error) {
 
 	task, ok := p.Tasks[taskname]
 	if !ok {
-		return boberror.ErrTaskDoesNotExistF(taskname)
+		return usererror.Wrap(boberror.ErrTaskDoesNotExistF(taskname))
 	}
 
 	// compute input hash

--- a/bob/playbook/playbook.go
+++ b/bob/playbook/playbook.go
@@ -10,6 +10,7 @@ import (
 	"github.com/benchkram/bob/bobtask"
 	"github.com/benchkram/bob/bobtask/buildinfo"
 	"github.com/benchkram/bob/bobtask/hash"
+	"github.com/benchkram/bob/pkg/boberror"
 	"github.com/benchkram/bob/pkg/boblog"
 	"github.com/benchkram/bob/pkg/buildinfostore"
 	"github.com/benchkram/errz"
@@ -19,7 +20,6 @@ import (
 // The playbook defines the order in which tasks are allowed to run.
 // Also determines the possibility to run tasks in parallel.
 
-var ErrTaskDoesNotExist = fmt.Errorf("task does not exist")
 var ErrDone = fmt.Errorf("playbook is done")
 var ErrFailed = fmt.Errorf("playbook failed")
 var ErrUnexpectedTaskState = fmt.Errorf("task state is unsexpected")
@@ -88,7 +88,7 @@ const (
 func (p *Playbook) TaskNeedsRebuild(taskname string, hashIn hash.In) (rebuildRequired bool, cause RebuildCause, err error) {
 	ts, ok := p.Tasks[taskname]
 	if !ok {
-		return false, "", ErrTaskDoesNotExist
+		return false, "", boberror.ErrTaskDoesNotExistF(taskname)
 	}
 	task := ts.Task
 	coloredName := task.ColoredName()
@@ -208,7 +208,7 @@ func (p *Playbook) play() error {
 				t, ok := p.Tasks[dependentTaskName]
 				if !ok {
 					//fmt.Printf("Task %s does not exist", dependentTaskName)
-					return ErrTaskDoesNotExist
+					return boberror.ErrTaskDoesNotExistF(dependentTaskName)
 				}
 				// fmt.Printf("dependentTask %s which is in state %s\n", t.Task.Name(), t.State())
 
@@ -277,7 +277,7 @@ func (p *Playbook) ErrorChannel() <-chan error {
 func (p *Playbook) setTaskState(taskname string, state State, taskError error) error {
 	task, ok := p.Tasks[taskname]
 	if !ok {
-		return ErrTaskDoesNotExist
+		return boberror.ErrTaskDoesNotExistF(taskname)
 	}
 
 	task.SetState(state, taskError)
@@ -293,7 +293,7 @@ func (p *Playbook) setTaskState(taskname string, state State, taskError error) e
 func (p *Playbook) pack(taskname string, hash hash.In) error {
 	task, ok := p.Tasks[taskname]
 	if !ok {
-		return ErrTaskDoesNotExist
+		return boberror.ErrTaskDoesNotExistF(taskname)
 	}
 	return task.Task.ArtifactPack(hash)
 }
@@ -301,7 +301,7 @@ func (p *Playbook) pack(taskname string, hash hash.In) error {
 func (p *Playbook) storeHash(taskname string, buildinfo *buildinfo.I) error {
 	task, ok := p.Tasks[taskname]
 	if !ok {
-		return ErrTaskDoesNotExist
+		return boberror.ErrTaskDoesNotExistF(taskname)
 	}
 
 	return task.Task.WriteBuildinfo(buildinfo)
@@ -315,7 +315,7 @@ func (p *Playbook) ExecutionTime() time.Duration {
 func (p *Playbook) TaskStatus(taskname string) (ts *Status, _ error) {
 	status, ok := p.Tasks[taskname]
 	if !ok {
-		return ts, ErrTaskDoesNotExist
+		return ts, boberror.ErrTaskDoesNotExistF(taskname)
 	}
 	return status, nil
 }
@@ -326,7 +326,7 @@ func (p *Playbook) TaskCompleted(taskname string) (err error) {
 
 	task, ok := p.Tasks[taskname]
 	if !ok {
-		return ErrTaskDoesNotExist
+		return boberror.ErrTaskDoesNotExistF(taskname)
 	}
 
 	// compute input hash

--- a/bob/playbook/status_map.go
+++ b/bob/playbook/status_map.go
@@ -1,6 +1,9 @@
 package playbook
 
-import "github.com/benchkram/bob/pkg/boberror"
+import (
+	"github.com/benchkram/bob/pkg/boberror"
+	"github.com/benchkram/bob/pkg/usererror"
+)
 
 type StatusMap map[string]*Status
 
@@ -8,7 +11,7 @@ type StatusMap map[string]*Status
 func (tsm StatusMap) walk(root string, fn func(taskname string, _ *Status, _ error) error) error {
 	task, ok := tsm[root]
 	if !ok {
-		return boberror.ErrTaskDoesNotExistF(root)
+		return usererror.Wrap(boberror.ErrTaskDoesNotExistF(root))
 	}
 
 	err := fn(root, task, nil)

--- a/bob/playbook/status_map.go
+++ b/bob/playbook/status_map.go
@@ -1,12 +1,14 @@
 package playbook
 
+import "github.com/benchkram/bob/pkg/boberror"
+
 type StatusMap map[string]*Status
 
 // walk the task tree starting at root. Following dependend tasks.
 func (tsm StatusMap) walk(root string, fn func(taskname string, _ *Status, _ error) error) error {
 	task, ok := tsm[root]
 	if !ok {
-		return ErrTaskDoesNotExist
+		return boberror.ErrTaskDoesNotExistF(root)
 	}
 
 	err := fn(root, task, nil)

--- a/bob/run.go
+++ b/bob/run.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/benchkram/bob/bob/bobfile"
+	"github.com/benchkram/bob/pkg/boberror"
 	"github.com/benchkram/bob/pkg/ctl"
 	"github.com/benchkram/errz"
 )
@@ -167,7 +169,7 @@ func executeBuildTasksInPipeline(ctx context.Context, runname string, aggregate 
 
 		playbook, err := aggregate.Playbook(child)
 		if err != nil {
-			if errors.Is(err, ErrTaskDoesNotExist) {
+			if errors.Is(err, boberror.ErrTaskDoesNotExist) {
 				continue
 			}
 			errz.Fatal(err)

--- a/bobtask/error.go
+++ b/bobtask/error.go
@@ -7,7 +7,6 @@ var (
 	ErrHashesFileDoesNotExist = fmt.Errorf("hashes file does not exist")
 	ErrTaskHashDoesNotExist   = fmt.Errorf("task hash does not exist")
 	ErrHashInDoesNotExist     = fmt.Errorf("input-hash does not exist")
-	ErrTaskDoesNotExist       = fmt.Errorf("task does not exist")
 	ErrInvalidInput           = fmt.Errorf("invalid input")
 
 	ErrInvalidTargetDefinition  = fmt.Errorf("invalid target definition, can't find 'path' or 'image' directive")

--- a/bobtask/map.go
+++ b/bobtask/map.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sort"
 
+	"github.com/benchkram/bob/pkg/boberror"
 	"github.com/benchkram/bob/pkg/multilinecmd"
 	"github.com/benchkram/bob/pkg/nix"
 	"github.com/benchkram/errz"
@@ -21,7 +22,7 @@ func (tm Map) Walk(root string, parentLevel string, fn func(taskname string, _ T
 
 	task, ok := tm[taskname]
 	if !ok {
-		return ErrTaskDoesNotExist
+		return boberror.ErrTaskDoesNotExistF(taskname)
 	}
 
 	err := fn(taskname, task, nil)

--- a/bobtask/map.go
+++ b/bobtask/map.go
@@ -9,6 +9,7 @@ import (
 	"github.com/benchkram/bob/pkg/boberror"
 	"github.com/benchkram/bob/pkg/multilinecmd"
 	"github.com/benchkram/bob/pkg/nix"
+	"github.com/benchkram/bob/pkg/usererror"
 	"github.com/benchkram/errz"
 )
 
@@ -22,7 +23,7 @@ func (tm Map) Walk(root string, parentLevel string, fn func(taskname string, _ T
 
 	task, ok := tm[taskname]
 	if !ok {
-		return boberror.ErrTaskDoesNotExistF(taskname)
+		return usererror.Wrap(boberror.ErrTaskDoesNotExistF(taskname))
 	}
 
 	err := fn(taskname, task, nil)

--- a/pkg/boberror/boberror.go
+++ b/pkg/boberror/boberror.go
@@ -1,0 +1,9 @@
+package boberror
+
+import "fmt"
+
+var ErrTaskDoesNotExist = fmt.Errorf("task does not exist")
+
+func ErrTaskDoesNotExistF(task string) error {
+	return fmt.Errorf("[task: %s], %w", task, ErrTaskDoesNotExist)
+}


### PR DESCRIPTION
This PR assures invalid task names are reported as user errors.
```
$ bob build vfgf
Building nix dependencies...
[task: vfgf], task does not exist
```