### PR TITLE
`bob clone` infere protocol by flags and from url

### DIFF
--- a/cli/cmd_clone.go
+++ b/cli/cmd_clone.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/benchkram/bob/bob"
 	"github.com/benchkram/bob/pkg/usererror"
@@ -19,23 +20,39 @@ var CmdClone = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		failFast, err := cmd.Flags().GetBool("fail-fast")
 		errz.Fatal(err)
+		https, err := cmd.Flags().GetBool("https")
+		errz.Fatal(err)
+		ssh, err := cmd.Flags().GetBool("ssh")
+		errz.Fatal(err)
+
+		if ssh && https {
+			fmt.Printf("%s\n", aurora.Red("You can only use one of --ssh or --https"))
+			os.Exit(0)
+		}
+
+		var protocol string
+		if ssh {
+			protocol = "ssh"
+		} else if https {
+			protocol = "https"
+		}
 
 		var url string
 		if len(args) > 0 {
 			url = args[0]
 		}
-		runClone(url, failFast)
+		runClone(url, failFast, protocol)
 	},
 }
 
-func runClone(url string, failFast bool) {
+func runClone(url string, failFast bool, protocol string) {
 
 	if len(url) == 0 {
 		bob, err := bob.Bob(bob.WithRequireBobConfig())
 		errz.Fatal(err)
 
 		// Try to clone dependencies of current repo
-		err = bob.Clone(failFast)
+		err = bob.Clone(failFast, protocol)
 		errz.Fatal(err)
 
 		fmt.Printf("%s\n", aurora.Green("Cloned"))

--- a/cli/cmd_root.go
+++ b/cli/cmd_root.go
@@ -30,6 +30,8 @@ func init() {
 
 	// clone
 	CmdClone.Flags().Bool("fail-fast", false, "Fail on first error without user prompt")
+	CmdClone.Flags().Bool("ssh", false, "Prefer ssh for cloning")
+	CmdClone.Flags().Bool("https", false, "Prefer https for cloning")
 	rootCmd.AddCommand(CmdClone)
 
 	// workspace


### PR DESCRIPTION
This PR inferes the protocol from the given clone url (https, ssh) and uses it as prefered protocol, e.g. `bob clone https://cloneurl` .

In the case of `bob clone` called without a url it can be specified by the flags `bob clone --http` and `bob clone --ssh`