### PR TITLE
Fix negative duration for a running task on a failed dependsOn 

### DIFF
--- a/bob/playbook/build.go
+++ b/bob/playbook/build.go
@@ -42,6 +42,8 @@ func (p *Playbook) Build(ctx context.Context) (err error) {
 
 					p.Done()
 				}
+
+				processedTasks = append(processedTasks, t)
 			}
 		}(i + 1)
 	}
@@ -51,7 +53,6 @@ func (p *Playbook) Build(ctx context.Context) (err error) {
 		c := p.TaskChannel()
 		for t := range c {
 			boblog.Log.V(5).Info(fmt.Sprintf("Sending task %s", t.Name()))
-			processedTasks = append(processedTasks, t)
 
 			// blocks till a worker is available
 			queue <- t


### PR DESCRIPTION
closes [#326](https://github.com/benchkram/bob/issues/236)

The issue is that when a task fails we stop the playbook and show the summary of all processed tasks. 
However, some tasks still have state running playbook is closed. The will be displayed in the summary, but because the end time was not updated will show with minus.

 
