### PR TITLE
Fix auth rm current auth context

### DIFF
--- a/bob/auth.go
+++ b/bob/auth.go
@@ -26,7 +26,7 @@ func (b *B) DeleteAuthContext(name string) (err error) {
 
 	err = b.authStore.DeleteContext(name)
 	if errors.Is(err, auth.ErrNotFound) {
-		return usererror.Wrapm(err, "failed to delete authentication context")
+		return usererror.Wrapm(err, fmt.Sprintf("failed to delete context [%s]", name))
 	}
 
 	return err

--- a/bob/auth.go
+++ b/bob/auth.go
@@ -29,7 +29,7 @@ func (b *B) DeleteAuthContext(name string) (err error) {
 		return usererror.Wrapm(err, "failed to delete authentication context")
 	}
 
-	return nil
+	return err
 }
 
 func (b *B) AuthContexts() ([]auth.Context, error) {

--- a/pkg/auth/store.go
+++ b/pkg/auth/store.go
@@ -114,7 +114,7 @@ func (s *Store) DeleteContext(name string) (err error) {
 			ctxs = append(ctxs[:i], ctxs[i+1:]...)
 			if c.Current && len(ctxs) > 0 {
 				// mark the next context as current (if any left)
-				ctxs[i].Current = true
+				ctxs[len(ctxs)-1].Current = true
 			}
 
 			break


### PR DESCRIPTION
closes #241 

The issue was happening only when the current auth token which you were was the most recent one created. Attempting to delete it would trigger an index out of range error. That error was ignored, so the only output was `Context 'whatever' deleted.`



