### PR TITLE
Fix broken logo URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 <p align="center">
-  <img  width="300" src="https://bob.build/assets/logo.654a7917.svg" />
+  <img  width="300" src="https://bob.build/assets/logo.070b920e.svg" />
 </p>
 <p align="center">
 Write Once, Build Once, Anywhere


### PR DESCRIPTION
The Bob logo at the top of the README points to `https://bob.build/assets/logo.654a7917.svg`, which is no longer a valid URL for this file as it returns a 404.
There is a working image link on https://bob.build/, the only difference is the hash(?) in the file name, now `070b920e` instead of `654a7917`.

Previously with 
```html
<img  width="300" src="https://bob.build/assets/logo.654a7917.svg" />
```
-> <img  width="300" src="https://bob.build/assets/logo.654a7917.svg" />

This change with
```html
<img  width="300" src="https://bob.build/assets/logo.070b920e.svg" />
```
-> <img  width="300" src="https://bob.build/assets/logo.070b920e.svg" />