### PR TITLE
Ignore SHLVL when hashing the environment

### DIFF
--- a/bobtask/hash_in.go
+++ b/bobtask/hash_in.go
@@ -84,7 +84,7 @@ func (t *Task) computeInputHash() (taskHash hash.In, err error) {
 }
 
 func filterEnvOfIgnores(env []string) []string {
-	ignore := []string{"buildCommandPath"}
+	ignore := []string{"buildCommandPath", "SHLVL"}
 
 	var result []string
 	for _, v := range env {


### PR DESCRIPTION
This issue was detected when using `ttyd` or if a shell was spawned into another shell. Nix passes SHLVL through [for their own reasons](https://github.com/NixOS/nix/pull/1275) and it can change between terminal instances, so we shouldn't include it in the hash.