### PR TITLE
experimenting with optimizations

### DIFF
--- a/bob/bobfile/playbook.go
+++ b/bob/bobfile/playbook.go
@@ -7,17 +7,33 @@ import (
 
 func (b *Bobfile) Playbook(taskName string, opts ...playbook.Option) (*playbook.Playbook, error) {
 
+	var idCounter int
 	pb := playbook.New(
 		taskName,
+		idCounter,
 		opts...,
 	)
+	idCounter++
 
 	err := b.BTasks.Walk(taskName, "", func(tn string, task bobtask.Task, err error) error {
 		if err != nil {
 			return err
 		}
+		if taskName == tn {
+			// The root task already has an id
+			statusTask := playbook.NewStatus(&task)
+			pb.Tasks[tn] = statusTask
+			pb.TasksOptimized = append(pb.TasksOptimized, statusTask)
+			return nil
+		}
 
-		pb.Tasks[tn] = playbook.NewStatus(&task)
+		task.TaskID = idCounter
+		statusTask := playbook.NewStatus(&task)
+
+		pb.Tasks[tn] = statusTask
+		pb.TasksOptimized = append(pb.TasksOptimized, statusTask)
+
+		idCounter++
 
 		return nil
 	})

--- a/bob/bobfile/verify.go
+++ b/bob/bobfile/verify.go
@@ -23,8 +23,8 @@ func (b *Bobfile) VerifyAfter() error {
 func (b *Bobfile) verifyBefore() (err error) {
 	defer errz.Recover(&err)
 
-	err = b.BTasks.VerifyDuplicateTargets()
-	errz.Fatal(err)
+	// err = b.BTasks.VerifyDuplicateTargets()
+	// errz.Fatal(err)
 
 	for _, task := range b.BTasks {
 		err = task.VerifyBefore()

--- a/bob/playbook/build.go
+++ b/bob/playbook/build.go
@@ -114,7 +114,7 @@ func (p *Playbook) Build(ctx context.Context) (err error) {
 		)
 	}
 
-	p.summary(processedTasks)
+	//p.summary(processedTasks)
 
 	if len(processingErrors) > 0 {
 		// Pass only the very first processing error.

--- a/bob/playbook/play.go
+++ b/bob/playbook/play.go
@@ -112,11 +112,13 @@ func (p *Playbook) Next() (_ *bobtask.Task, err error) {
 	for r := range c {
 		switch r.state {
 		case "queued":
-			//fmt.Printf("received task %s and returning\n", r.t.Name())
+			fmt.Printf("received task %s and returning\n", r.t.Name())
 			return r.t, nil
 		case "failed":
+			fmt.Println("failed")
 			fallthrough
 		case "playbook-done":
+			fmt.Println("playbook-done")
 			p.done = true
 			return nil, ErrDone
 		}

--- a/bob/playbook/play.go
+++ b/bob/playbook/play.go
@@ -106,3 +106,101 @@ func (p *Playbook) play() error {
 
 	return nil
 }
+
+func (p *Playbook) playOnce() error {
+
+	if p.done {
+		return ErrDone
+	}
+	p.oncePrepareOptimizedAccess.Do(func() {
+		_ = p.Tasks.walk(p.root, func(taskname string, task *Status, _ error) error {
+			for _, dependentTaskName := range task.DependsOn {
+				t := p.Tasks[dependentTaskName]
+				task.DependsOnIDs = append(task.DependsOnIDs, t.TaskID)
+			}
+			return nil
+		})
+	})
+
+	p.playMutex.Lock()
+	defer p.playMutex.Unlock()
+
+	if p.start.IsZero() {
+		p.start = time.Now()
+	}
+
+	// Walk the task chain and determine the next build task. Send it to the task channel.
+	// Returns `taskQueued` when a task has been send to the taskChannel.
+	// Returns `taskFailed` when a task has failed.
+	// Once it returns `nil` the playbook is done with it's work.
+	var taskQueued = fmt.Errorf("task queued")
+	var taskFailed = fmt.Errorf("task failed")
+	//var noTaskReadyToRun = fmt.Errorf("no task ready to run")
+	err := p.TasksOptimized.walk(p.rootID, func(taskID int, task *Status, err error) error {
+		if err != nil {
+			return err
+		}
+
+		//boblog.Log.V(3).Info(fmt.Sprintf("%-*s\t walking", p.namePad, taskname))
+
+		switch task.State() {
+		case StatePending:
+			// Check if all dependent tasks are completed
+			for _, dependentTaskID := range task.Task.DependsOnIDs {
+				t := p.TasksOptimized[dependentTaskID]
+
+				state := t.State()
+				if state != StateCompleted && state != StateNoRebuildRequired {
+					// A dependent task is not completed.
+					// So this task is not yet ready to run.
+					return nil
+				}
+			}
+		case StateFailed:
+			return taskFailed
+		case StateCanceled:
+			return nil
+		case StateNoRebuildRequired:
+			return nil
+		case StateCompleted:
+			return nil
+		case StateRunning:
+			return nil
+		case StateQueued:
+			return nil
+		default:
+		}
+
+		// fmt.Printf("sending task %s to channel\n", task.Task.Name())
+		// setting the task start time before passing it to channel
+		task.SetStart(time.Now())
+		// TODO: for async assure to handle send to a closed channel.
+		_ = p.setTaskState(task.Name(), StateRunning, nil)
+		p.taskChannel <- task.Task
+		return taskQueued
+	})
+
+	// taskQueued => return nil (happy path)
+	// taskFailed => return PlaybookFailed (ErrFailed)
+	// default    => return err
+	if err != nil {
+		if errors.Is(err, taskQueued) {
+			return nil
+		}
+		if errors.Is(err, taskFailed) {
+			return ErrFailed
+		}
+		return err
+	}
+
+	// When arriving here it means that either there is currently
+	// no work necessary or that the playbook is done processing all tasks.
+
+	// Finishing the playbook when there is no work left.
+	if !p.hasRunningOrPendingTasks() {
+		p.Done()
+		return ErrDone
+	}
+
+	return nil
+}

--- a/bob/playbook/play.go
+++ b/bob/playbook/play.go
@@ -4,11 +4,160 @@ import (
 	"errors"
 	"fmt"
 	"time"
+
+	"github.com/benchkram/bob/bobtask"
 )
 
 func (p *Playbook) Play() (err error) {
 
 	return p.playOnce()
+}
+
+func (p *Playbook) Next() (_ *bobtask.Task, err error) {
+	if p.done {
+		return nil, ErrDone
+	}
+	p.oncePrepareOptimizedAccess.Do(func() {
+		_ = p.Tasks.walk(p.root, func(taskname string, task *Status, _ error) error {
+			for _, dependentTaskName := range task.DependsOn {
+				t := p.Tasks[dependentTaskName]
+				task.DependsOnIDs = append(task.DependsOnIDs, t.TaskID)
+			}
+			return nil
+		})
+	})
+
+	// Required?
+	p.playMutex.Lock()
+	defer p.playMutex.Unlock()
+
+	if p.start.IsZero() {
+		p.start = time.Now()
+	}
+
+	// Walk the task chain and determine the next build task. Send it to the task channel.
+	// Returns `taskQueued` when a task has been send to the taskChannel.
+	// Returns `taskFailed` when a task has failed.
+	// Once it returns `nil` the playbook is done with it's work.
+	var taskQueued = fmt.Errorf("task queued")
+	var taskFailed = fmt.Errorf("task failed")
+	//var noTaskReadyToRun = fmt.Errorf("no task ready to run")
+
+	type result struct {
+		t     *bobtask.Task
+		state string // queued, playbook-done, failed
+	}
+	c := make(chan result, 1)
+
+	// Starting the walk function in a goroutine to be able
+	// to return  a ready to be processed task immeadiately
+	// from Next().
+	go func(output chan result) {
+		didAllTaskComplete := true
+		_ = p.TasksOptimized.walkBottomFirst(p.rootID, func(taskID int, task *Status, err error) error {
+			if err != nil {
+				return err
+			}
+
+			//boblog.Log.V(3).Info(fmt.Sprintf("%-*d\t walking", p.namePad, taskID))
+
+			switch task.State() {
+			case StatePending:
+				didAllTaskComplete = false
+				// Check if all dependent tasks are completed
+				for _, dependentTaskID := range task.Task.DependsOnIDs {
+					t := p.TasksOptimized[dependentTaskID]
+
+					state := t.State()
+					if state != StateCompleted && state != StateNoRebuildRequired {
+						// A dependent task is not completed.
+						// So this task is not yet ready to run.
+						return nil
+					}
+				}
+			case StateFailed:
+				//output <- result{t: task.Task, state: "failed"}
+				return taskFailed
+			case StateCanceled:
+				//output <- result{t: task.Task, state: "canceled"}
+				return nil
+			case StateNoRebuildRequired:
+				return nil
+			case StateCompleted:
+				return nil
+			case StateRunning:
+				didAllTaskComplete = false
+				return nil
+			case StateQueued:
+				didAllTaskComplete = false
+				return nil
+			default:
+			}
+
+			//fmt.Printf("sending task %s to channel\n", task.Task.Name())
+			// setting the task start time before passing it to channel
+			task.SetStart(time.Now())
+			// TODO: for async assure to handle send to a closed channel.
+			_ = p.setTaskState(task.Name(), StateRunning, nil)
+			output <- result{t: task.Task, state: "queued"}
+			return taskQueued
+		})
+
+		if didAllTaskComplete {
+			output <- result{t: nil, state: "playbook-done"}
+		}
+		close(output)
+	}(c)
+
+	for r := range c {
+		switch r.state {
+		case "queued":
+			//fmt.Printf("received task %s and returning\n", r.t.Name())
+			return r.t, nil
+		case "failed":
+			fallthrough
+		case "playbook-done":
+			p.done = true
+			return nil, ErrDone
+		}
+	}
+
+	//fmt.Printf("returning without a task\n")
+	return nil, nil
+	// // wait
+	// select {
+	// case cc := <-c:
+	// 	// task ready
+	// 	fmt.Printf("received task %s and returning\n", cc.Name())
+	// 	return cc, nil
+	// default:
+	// 	// no task ready
+	// 	fmt.Printf("returning without a task\n")
+	// 	return nil, nil
+	// }
+
+	// // taskQueued => return nil (happy path)
+	// // taskFailed => return PlaybookFailed (ErrFailed)
+	// // default    => return err
+	// if err != nil {
+	// 	if errors.Is(err, taskQueued) {
+	// 		return nil, nil
+	// 	}
+	// 	if errors.Is(err, taskFailed) {
+	// 		return nil, ErrFailed
+	// 	}
+	// 	return nil, err
+	// }
+
+	// // When arriving here it means that either there is currently
+	// // no work necessary or that the playbook is done processing all tasks.
+
+	// // Finishing the playbook when there is no work left.
+	// if !p.hasRunningOrPendingTasks() {
+	// 	p.Done()
+	// 	return nil, ErrDone
+	// }
+
 }
 
 func (p *Playbook) play() error {

--- a/bob/playbook/play.go
+++ b/bob/playbook/play.go
@@ -32,6 +32,7 @@ func (p *Playbook) play() error {
 	// Once it returns `nil` the playbook is done with it's work.
 	var taskQueued = fmt.Errorf("task queued")
 	var taskFailed = fmt.Errorf("task failed")
+	//var noTaskReadyToRun = fmt.Errorf("no task ready to run")
 	err := p.Tasks.walk(p.root, func(taskname string, task *Status, err error) error {
 		if err != nil {
 			return err

--- a/bob/playbook/playbook.go
+++ b/bob/playbook/playbook.go
@@ -126,7 +126,7 @@ const (
 )
 
 func (p *Playbook) hasRunningOrPendingTasks() bool {
-	var num int
+	var runningOrPending bool
 	_ = p.Tasks.walk(p.root, func(taskname string, task *Status, err error) error {
 		if err != nil {
 			return err
@@ -134,12 +134,13 @@ func (p *Playbook) hasRunningOrPendingTasks() bool {
 
 		state := task.State()
 		if state == StateRunning || state == StatePending {
-			num++
+			runningOrPending = true
+			return ErrWalkDone
 		}
 
 		return nil
 	})
-	return num > 0
+	return runningOrPending
 }
 
 func (p *Playbook) Done() {

--- a/bob/playbook/playbook.go
+++ b/bob/playbook/playbook.go
@@ -2,7 +2,6 @@ package playbook
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"runtime"
 	"sort"
@@ -214,12 +213,12 @@ func (p *Playbook) TaskCompleted(taskname string) (err error) {
 	// update task state and trigger another playbook run
 	err = p.setTaskState(taskname, StateCompleted, nil)
 	errz.Fatal(err)
-	err = p.play()
-	if err != nil {
-		if !errors.Is(err, ErrDone) {
-			errz.Fatal(err)
-		}
-	}
+	// err = p.play()
+	// if err != nil {
+	// 	if !errors.Is(err, ErrDone) {
+	// 		errz.Fatal(err)
+	// 	}
+	// }
 
 	return nil
 }
@@ -231,12 +230,12 @@ func (p *Playbook) TaskNoRebuildRequired(taskname string) (err error) {
 	err = p.setTaskState(taskname, StateNoRebuildRequired, nil)
 	errz.Fatal(err)
 
-	err = p.play()
-	if err != nil {
-		if !errors.Is(err, ErrDone) {
-			errz.Fatal(err)
-		}
-	}
+	// err = p.play()
+	// if err != nil {
+	// 	if !errors.Is(err, ErrDone) {
+	// 		errz.Fatal(err)
+	// 	}
+	// }
 
 	return nil
 }
@@ -252,7 +251,7 @@ func (p *Playbook) TaskFailed(taskname string, taskErr error) (err error) {
 
 	// give the playbook the chance to set
 	// the state to done.
-	_ = p.play()
+	//_ = p.play()
 
 	return nil
 }

--- a/bob/playbook/state.go
+++ b/bob/playbook/state.go
@@ -35,6 +35,8 @@ func (s *State) Short() string {
 		return "failed"
 	case StateCanceled:
 		return "canceled"
+	case StateQueued:
+		return "queued"
 	default:
 		return ""
 	}
@@ -47,4 +49,5 @@ const (
 	StateFailed            State = "FAILED"
 	StateRunning           State = "RUNNING"
 	StateCanceled          State = "CANCELED"
+	StateQueued            State = "QUEUED"
 )

--- a/bob/playbook/status.go
+++ b/bob/playbook/status.go
@@ -12,7 +12,7 @@ import (
 type Status struct {
 	*bobtask.Task
 
-	stateMu sync.RWMutex
+	stateMu sync.Mutex
 	state   State
 
 	startMu sync.RWMutex
@@ -32,17 +32,17 @@ func NewStatus(task *bobtask.Task) *Status {
 }
 
 func (ts *Status) State() State {
-	ts.stateMu.RLock()
+	ts.stateMu.Lock()
 	state := ts.state
-	ts.stateMu.RUnlock()
+	ts.stateMu.Unlock()
 	return state
 }
 
 func (ts *Status) SetState(s State, err error) {
 	ts.stateMu.Lock()
-	defer ts.stateMu.Unlock()
 	ts.state = s
 	ts.Error = err
+	ts.stateMu.Unlock()
 }
 
 func (ts *Status) ExecutionTime() time.Duration {

--- a/bob/playbook/status.go
+++ b/bob/playbook/status.go
@@ -33,8 +33,9 @@ func NewStatus(task *bobtask.Task) *Status {
 
 func (ts *Status) State() State {
 	ts.stateMu.RLock()
-	defer ts.stateMu.RUnlock()
-	return ts.state
+	state := ts.state
+	ts.stateMu.RUnlock()
+	return state
 }
 
 func (ts *Status) SetState(s State, err error) {

--- a/bob/playbook/status_map.go
+++ b/bob/playbook/status_map.go
@@ -1,11 +1,15 @@
 package playbook
 
 import (
+	"fmt"
+
 	"github.com/benchkram/bob/pkg/boberror"
 	"github.com/benchkram/bob/pkg/usererror"
 )
 
 type StatusMap map[string]*Status
+
+var ErrWalkDone = fmt.Errorf("walking done")
 
 // walk the task tree starting at root. Following dependend tasks.
 func (tsm StatusMap) walk(root string, fn func(taskname string, _ *Status, _ error) error) error {

--- a/bob/playbook/status_map.go
+++ b/bob/playbook/status_map.go
@@ -31,3 +31,21 @@ func (tsm StatusMap) walk(root string, fn func(taskname string, _ *Status, _ err
 
 	return nil
 }
+
+// walk the task tree starting at root. Tasks deeper in the tree are walked first.
+func (tsm StatusMap) walkBottomFirst(root string, fn func(taskname string, _ *Status, _ error) error) error {
+	task, ok := tsm[root]
+	if !ok {
+		return usererror.Wrap(boberror.ErrTaskDoesNotExistF(root))
+	}
+
+	var err error
+	for _, dependentTaskName := range task.Task.DependsOn {
+		err = tsm.walk(dependentTaskName, fn)
+		if err != nil {
+			return err
+		}
+	}
+
+	return fn(root, task, err)
+}

--- a/bob/playbook/status_slice.go
+++ b/bob/playbook/status_slice.go
@@ -1,0 +1,41 @@
+package playbook
+
+type StatusSlice []*Status
+
+//var ErrWalkDone = fmt.Errorf("walking done")
+
+// walk the task tree starting at root. Following dependend tasks.
+func (tsm StatusSlice) walk(root int, fn func(taskID int, _ *Status, _ error) error) error {
+	task := tsm[root]
+
+	err := fn(root, task, nil)
+	if err != nil {
+		return err
+	}
+	for _, id := range task.Task.DependsOnIDs {
+		err = tsm.walk(id, fn)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// // walk the task tree starting at root. Tasks deeper in the tree are walked first.
+// func (tsm StatusMap) walkBottomFirst(root string, fn func(taskname string, _ *Status, _ error) error) error {
+// 	task, ok := tsm[root]
+// 	if !ok {
+// 		return usererror.Wrap(boberror.ErrTaskDoesNotExistF(root))
+// 	}
+
+// 	var err error
+// 	for _, dependentTaskName := range task.Task.DependsOn {
+// 		err = tsm.walk(dependentTaskName, fn)
+// 		if err != nil {
+// 			return err
+// 		}
+// 	}
+
+// 	return fn(root, task, err)
+// }

--- a/bob/playbook/status_slice.go
+++ b/bob/playbook/status_slice.go
@@ -22,20 +22,17 @@ func (tsm StatusSlice) walk(root int, fn func(taskID int, _ *Status, _ error) er
 	return nil
 }
 
-// // walk the task tree starting at root. Tasks deeper in the tree are walked first.
-// func (tsm StatusMap) walkBottomFirst(root string, fn func(taskname string, _ *Status, _ error) error) error {
-// 	task, ok := tsm[root]
-// 	if !ok {
-// 		return usererror.Wrap(boberror.ErrTaskDoesNotExistF(root))
-// 	}
+// walk the task tree starting at root. Tasks deeper in the tree are walked first.
+func (tsm StatusSlice) walkBottomFirst(root int, fn func(taskID int, _ *Status, _ error) error) error {
+	task := tsm[root]
 
-// 	var err error
-// 	for _, dependentTaskName := range task.Task.DependsOn {
-// 		err = tsm.walk(dependentTaskName, fn)
-// 		if err != nil {
-// 			return err
-// 		}
-// 	}
+	var err error
+	for _, id := range task.Task.DependsOnIDs {
+		err = tsm.walk(id, fn)
+		if err != nil {
+			return err
+		}
+	}
 
-// 	return fn(root, task, err)
-// }
+	return fn(root, task, err)
+}

--- a/bobtask/hash_in.go
+++ b/bobtask/hash_in.go
@@ -9,12 +9,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/benchkram/bob/pkg/boblog"
-	"github.com/benchkram/bob/pkg/sliceutil"
-	"gopkg.in/yaml.v2"
-
 	"github.com/benchkram/bob/bobtask/hash"
+	"github.com/benchkram/bob/pkg/boblog"
 	"github.com/benchkram/bob/pkg/filehash"
+	"github.com/benchkram/bob/pkg/sliceutil"
 )
 
 // HashInAlways computes the input hash without using a cached value
@@ -49,11 +47,7 @@ func (t *Task) computeInputHash() (taskHash hash.In, err error) {
 	}
 
 	// Hash the public task description
-	description, err := yaml.Marshal(t)
-	if err != nil {
-		return taskHash, fmt.Errorf("failed to marshal task: %w", err)
-	}
-	err = h.AddBytes(bytes.NewBuffer(description))
+	err = h.AddBytes(strings.NewReader(t.Description()))
 	if err != nil {
 		return taskHash, fmt.Errorf("failed to write description hash: %w", err)
 	}

--- a/bobtask/task.go
+++ b/bobtask/task.go
@@ -22,7 +22,7 @@ const (
 
 // Hint: When adding a new *Dirty field assure to update IsValidDecoration().
 type Task struct {
-	// Inputs are directorys or files
+	// Inputs are directories or files
 	// the task monitors for a rebuild.
 
 	// InputDirty is the representation read from a bobfile.
@@ -178,4 +178,21 @@ func (t *Task) IsValidDecoration() bool {
 		return false
 	}
 	return true
+}
+
+func (t *Task) Description() string {
+	var sb strings.Builder
+
+	sb.WriteString(t.InputDirty)
+	sb.WriteString(t.CmdDirty)
+	sb.WriteString(strings.Join(t.DependsOn, ","))
+	sb.WriteString(t.RebuildDirty)
+	sb.WriteString(strings.Join(t.DependenciesDirty, ","))
+
+	if t.target != nil {
+		sb.WriteString(strings.Join(t.target.DockerImages(), ","))
+		sb.WriteString(strings.Join(t.target.FilesystemEntriesRaw(), ","))
+	}
+
+	return sb.String()
 }

--- a/bobtask/task.go
+++ b/bobtask/task.go
@@ -41,6 +41,10 @@ type Task struct {
 	// can run.
 	DependsOn []string `yaml:"dependsOn,omitempty"`
 
+	// dependsOnIDs task id's used for optimization.
+	// Not exposed in a Bobfile.
+	DependsOnIDs []int `yaml:"-"`
+
 	// Target defines the output of a task.
 	TargetDirty TargetEntry `yaml:"target,omitempty"`
 	target      *target.T
@@ -52,6 +56,11 @@ type Task struct {
 	// name is the name of the task
 	// TODO: Make this public to allow yaml.Marshal to add this to the task hash?!?
 	name string
+
+	// taskID is a integer provided to
+	// avoid referencing tasks by name
+	// (string comparison, map access)
+	TaskID int
 
 	// project this tasks belongs to
 	project string

--- a/pkg/nix/nix.go
+++ b/pkg/nix/nix.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/benchkram/bob/bob/global"
+	"github.com/benchkram/bob/pkg/filehash"
 	"github.com/benchkram/bob/pkg/format"
 	"github.com/benchkram/bob/pkg/usererror"
 	"github.com/benchkram/errz"
@@ -22,6 +23,17 @@ type Dependency struct {
 	// Nixpkgs can be empty or a link to desired revision
 	// ex. https://github.com/NixOS/nixpkgs/archive/eeefd01d4f630fcbab6588fe3e7fffe0690fbb20.tar.gz
 	Nixpkgs string
+}
+
+func HashDependencies(deps []Dependency) (string, error) {
+	hash := filehash.New()
+	for _, dep := range deps {
+		err := hash.AddBytes(bytes.NewBuffer([]byte(dep.Name + dep.Nixpkgs)))
+		if err != nil {
+			return "", err
+		}
+	}
+	return string(hash.Sum()), nil
 }
 
 // IsInstalled checks if nix is installed on the system


### PR DESCRIPTION
Performance optimizations:
* [x] Use ints to reference between tasks instead of a hash map.
* [x] Use `play()` less often.
* [ ] Create the build graph in one walk.
* [x] Ignore duplicate target check (till optimized). #286 
* [x] Use env cash to BuildNixDep less often. #287 

Brings down raw `bob` overhead from ~3s to 720ms on a repository containing 5000 Golang projects.