### PR TITLE
Fix child bobfile target ignoring

### DIFF
--- a/bob/aggregate.go
+++ b/bob/aggregate.go
@@ -221,7 +221,7 @@ func (b *B) Aggregate() (aggregate *bobfile.Bobfile, err error) {
 	err = aggregate.Verify()
 	errz.Fatal(err)
 
-	err = aggregate.BTasks.IgnoreChildTargets()
+	err = aggregate.BTasks.IgnoreChildTargets(aggregate.Dir())
 	errz.Fatal(err)
 
 	// Filter input must run before any work is done.

--- a/bobtask/input.go
+++ b/bobtask/input.go
@@ -112,7 +112,8 @@ func (t *Task) FilteredInputs(projectRoot string) (_ []string, err error) {
 	}
 
 	// Ignore additional items found during aggregation.
-	// Usually the targets of child tasks which are already rooted.
+	// Usually the targets of child tasks which are already
+	// relative to the umbrella Bobfile.
 	for _, path := range t.InputAdditionalIgnores {
 		info, err := os.Lstat(path)
 		if err != nil {

--- a/bobtask/map.go
+++ b/bobtask/map.go
@@ -189,7 +189,8 @@ func (tm Map) CollectNixDependenciesForTasks(whitelist []string) ([]nix.Dependen
 
 // IgnoreChildTargets fills the `InputAdditionalIgnores` field of each task
 // with the targets of each tasks children.
-func (tm Map) IgnoreChildTargets() (err error) {
+// dir should be the root of the aggregate, and it is used to ignore resolved targets relative to this project
+func (tm Map) IgnoreChildTargets(dir string) (err error) {
 	defer errz.Recover(&err)
 	for name, umbrellaTask := range tm {
 
@@ -222,7 +223,7 @@ func (tm Map) IgnoreChildTargets() (err error) {
 						//
 						//     third-level    fouth-level           second-level/third-level/fourth-level/target
 
-						relP, err := filepath.Rel(umbrellaTask.Dir(), p)
+						relP, err := filepath.Rel(dir, p)
 						if err != nil {
 							return err
 						}

--- a/bobtask/map.go
+++ b/bobtask/map.go
@@ -187,9 +187,10 @@ func (tm Map) CollectNixDependenciesForTasks(whitelist []string) ([]nix.Dependen
 	return nixDependencies, nil
 }
 
-// IgnoreChildTargets fills the `InputAdditionalIgnores` field of each task
-// with the targets of each tasks children.
-// dir should be the root of the aggregate, and it is used to ignore resolved targets relative to this project
+// IgnoreChildTargets fills the `InputAdditionalIgnores` field of
+// each task  with the targets of each tasks children.
+// `dir` must be the root of the aggregate, and it is used
+// to ignore resolved targets relative to this project
 func (tm Map) IgnoreChildTargets(dir string) (err error) {
 	defer errz.Recover(&err)
 	for name, umbrellaTask := range tm {


### PR DESCRIPTION
This PR resolves caching issues that stemmed from the incorrect ignoring of child targets as inputs, for example in cases of task decoration.

Closes #318