### PR TITLE
Lazily initialize docker registry client

### DIFF
--- a/bob/aggregate.go
+++ b/bob/aggregate.go
@@ -219,19 +219,11 @@ func (b *B) Aggregate() (aggregate *bobfile.Bobfile, err error) {
 		aggregate.Project = aggregate.Dir()
 	}
 
-	err = aggregate.Verify()
-	errz.Fatal(err)
-
-	err = aggregate.BTasks.IgnoreChildTargets(aggregate.Dir())
-	errz.Fatal(err)
-
-	// Filter input must run before any work is done.
-	err = aggregate.BTasks.FilterInputs()
-	errz.Fatal(err)
-
 	var dockerRegistryClientInitialized bool
 
-	// Assure tasks are correctly initialised.
+	// Assure tasks are correctly initialised with a docker registry client.
+	// Only one registry client must be created and shared between tasks,
+	// this reduces the pressure on garbage collection for big repos.
 	for i, task := range aggregate.BTasks {
 		target, err := task.Target()
 		errz.Fatal(err)
@@ -252,6 +244,16 @@ func (b *B) Aggregate() (aggregate *bobfile.Bobfile, err error) {
 			aggregate.BTasks[i] = task
 		}
 	}
+
+	err = aggregate.Verify()
+	errz.Fatal(err)
+
+	err = aggregate.BTasks.IgnoreChildTargets(aggregate.Dir())
+	errz.Fatal(err)
+
+	// Filter input must run before any work is done.
+	err = aggregate.BTasks.FilterInputs()
+	errz.Fatal(err)
 
 	return aggregate, nil
 }

--- a/bob/bob.go
+++ b/bob/bob.go
@@ -81,8 +81,6 @@ func newBob(opts ...Option) *B {
 		enableCaching: true,
 		allowInsecure: false,
 		maxParallel:   runtime.NumCPU(),
-
-		dockerRegistryClient: dockermobyutil.NewRegistryClient(),
 	}
 
 	for _, opt := range opts {

--- a/bob/bobfile/bobfile.go
+++ b/bob/bobfile/bobfile.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/benchkram/bob/pkg/dockermobyutil"
 	"github.com/benchkram/bob/pkg/nix"
 	storeclient "github.com/benchkram/bob/pkg/store-client"
 
@@ -139,9 +138,6 @@ func bobfileRead(dir string) (_ *Bobfile, err error) {
 		bobfile.RTasks = bobrun.RunMap{}
 	}
 
-	// a shared registry clients for all tasks.
-	dockerRegistryClient := dockermobyutil.NewRegistryClient()
-
 	// Assure tasks are initialized with their defaults
 	for key, task := range bobfile.BTasks {
 		task.SetDir(bobfile.dir)
@@ -153,7 +149,6 @@ func bobfileRead(dir string) (_ *Bobfile, err error) {
 		// This means switching to pointer types for most members.
 		task.SetEnv([]string{})
 		task.SetRebuildStrategy(bobtask.RebuildOnChange)
-		task.WithDockerRegistryClient(dockerRegistryClient)
 
 		// initialize docker registry for task
 		task.SetDependencies(initializeDependencies(dir, task.DependenciesDirty, bobfile))

--- a/bob/playbook/build_internal.go
+++ b/bob/playbook/build_internal.go
@@ -130,11 +130,10 @@ func (p *Playbook) build(ctx context.Context, task *bobtask.Task) (pt *processed
 	taskSuccessFul = true
 
 	err = p.TaskCompleted(task.TaskID)
-	if err != nil {
-		if errors.Is(err, ErrFailed) {
-			return pt, err
-		}
+	if errors.Is(err, ErrFailed) {
+		return pt, err
 	}
+	errz.Log(err)
 	errz.Fatal(err)
 
 	taskStatus, err := p.TaskStatus(task.Name())

--- a/bobtask/target.go
+++ b/bobtask/target.go
@@ -10,11 +10,14 @@ import (
 )
 
 // Target takes care of populating the targets members correctly.
-// It returns a nil in case of a non existing target and a nil error.
+// It returns a nil in case of a non-existing target and a nil error.
 func (t *Task) Target() (empty target.Target, _ error) {
 	if t.target == nil {
 		return empty, nil
 	}
+
+	// attach docker registry client (if set) to target itself
+	t.target.WithDockerRegistryClient(t.dockerRegistryClient)
 
 	// ReadBuildInfo is dependent on the inputHash of the task.
 	// For this reason we cannot read build info on target creation,
@@ -41,8 +44,10 @@ func (t *Task) Target() (empty target.Target, _ error) {
 		return t.target, t.target.Resolve()
 	}
 
-	tt := t.target.WithExpected(&buildInfo.Target)
-	return tt, tt.Resolve()
+	// attach expected buildinfo
+	t.target.WithExpected(&buildInfo.Target)
+
+	return t.target, t.target.Resolve()
 }
 
 func (t *Task) TargetExists() bool {

--- a/bobtask/target/options.go
+++ b/bobtask/target/options.go
@@ -1,10 +1,5 @@
 package target
 
-import (
-	"github.com/benchkram/bob/bobtask/buildinfo"
-	"github.com/benchkram/bob/pkg/dockermobyutil"
-)
-
 type Option func(t *T)
 
 func WithDir(dir string) Option {
@@ -22,17 +17,5 @@ func WithFilesystemEntries(entries []string) Option {
 func WithDockerImages(images []string) Option {
 	return func(t *T) {
 		t.dockerImages = images
-	}
-}
-
-func WithDockerRegistryClient(dockerRegistryClient dockermobyutil.RegistryClient) Option {
-	return func(t *T) {
-		t.dockerRegistryClient = dockerRegistryClient
-	}
-}
-
-func WithExpected(bi *buildinfo.Targets) Option {
-	return func(t *T) {
-		t.expected = bi
 	}
 }

--- a/bobtask/target/target.go
+++ b/bobtask/target/target.go
@@ -19,7 +19,7 @@ type Target interface {
 	FilesystemEntriesRaw() []string
 	FilesystemEntriesRawPlain() []string
 
-	WithExpected(*buildinfo.Targets) *T
+	WithExpected(*buildinfo.Targets)
 	DockerImages() []string
 
 	// AsInvalidFiles returns all FilesystemEntriesRaw as invalid with the specified reason
@@ -68,10 +68,6 @@ func New(opts ...Option) *T {
 		opt(t)
 	}
 
-	if t.dockerRegistryClient == nil {
-		t.dockerRegistryClient = dockermobyutil.NewRegistryClient()
-	}
-
 	return t
 }
 
@@ -109,9 +105,12 @@ func (t *T) FilesystemEntriesRawPlain() []string {
 	return append([]string{}, t.filesystemEntriesRaw...)
 }
 
-func (t *T) WithExpected(expected *buildinfo.Targets) *T {
+func (t *T) WithExpected(expected *buildinfo.Targets) {
 	t.expected = expected
-	return t
+}
+
+func (t *T) WithDockerRegistryClient(c dockermobyutil.RegistryClient) {
+	t.dockerRegistryClient = c
 }
 
 func (t *T) DockerImages() []string {

--- a/bobtask/target_parse.go
+++ b/bobtask/target_parse.go
@@ -75,7 +75,6 @@ func (t *Task) parseTargets() error {
 			target.WithFilesystemEntries(filesystemEntries),
 			target.WithDockerImages(dockerImages),
 			target.WithDir(t.dir),
-			target.WithDockerRegistryClient(t.dockerRegistryClient),
 		)
 	}
 

--- a/bobtask/task.go
+++ b/bobtask/task.go
@@ -135,10 +135,6 @@ func Make(opts ...TaskOption) Task {
 		opt(&t)
 	}
 
-	if t.dockerRegistryClient == nil {
-		t.dockerRegistryClient = dockermobyutil.NewRegistryClient()
-	}
-
 	return t
 }
 

--- a/test/e2e/artifacts/artifacts_extraction_test.go
+++ b/test/e2e/artifacts/artifacts_extraction_test.go
@@ -77,7 +77,8 @@ var _ = Describe("Test artifact creation and extraction", func() {
 var _ = Describe("Test artifact creation and extraction from docker targets", func() {
 	Context("in a fresh playground", func() {
 
-		mobyClient := dockermobyutil.NewRegistryClient()
+		mobyClient, err := dockermobyutil.NewRegistryClient()
+		Expect(err).NotTo(HaveOccurred())
 
 		It("should initialize bob playground", func() {
 			Expect(bob.CreatePlayground(bob.PlaygroundOptions{Dir: dir})).NotTo(HaveOccurred())

--- a/test/e2e/artifacts/artifacts_test.go
+++ b/test/e2e/artifacts/artifacts_test.go
@@ -102,11 +102,12 @@ var _ = Describe("Test artifact and target invalidation", func() {
 	})
 })
 
-//  docker targets
+// docker targets
 var _ = Describe("Test artifact and docker-target invalidation", func() {
 	Context("in a fresh playground", func() {
 
-		mobyClient := dockermobyutil.NewRegistryClient()
+		mobyClient, err := dockermobyutil.NewRegistryClient()
+		Expect(err).NotTo(HaveOccurred())
 
 		It("should initialize bob playground", func() {
 			Expect(bob.CreatePlayground(bob.PlaygroundOptions{Dir: dir})).NotTo(HaveOccurred())

--- a/test/e2e/artifacts/nobuildinfo_test.go
+++ b/test/e2e/artifacts/nobuildinfo_test.go
@@ -104,7 +104,8 @@ var _ = Describe("Test artifact and target lifecycle without existing buildinfo"
 var _ = Describe("Test artifact and target lifecycle for docker images without existing buildinfo", func() {
 	Context("in a fresh playground", func() {
 
-		mobyClient := dockermobyutil.NewRegistryClient()
+		mobyClient, err := dockermobyutil.NewRegistryClient()
+		Expect(err).NotTo(HaveOccurred())
 
 		It("should initialize bob playground", func() {
 			Expect(bob.CreatePlayground(bob.PlaygroundOptions{Dir: dir})).NotTo(HaveOccurred())


### PR DESCRIPTION
This PR allows running bob without errors if:
- bobfile has no tasks declared with docker images as targets (no need to interface with docker at all), or
- bobfile has such tasks, but the command being run (e.g. `bob build ls`) does not require interaction with docker.

If the bobfile requires docker for some operation, and docker is not present, then it exits early with a user error, without showing a stacktrace.

It also addresses a potential mutex bug (Unlock was not deferred and there was no unlock call in an if-return branch later on).

It should address issues reported by users not having Docker installed, e.g. #327 